### PR TITLE
Cleanup color picker formatting in editor

### DIFF
--- a/src/assets/admin/css/style.scss
+++ b/src/assets/admin/css/style.scss
@@ -219,6 +219,18 @@
     .components-base-control__label {
         display: flex;
         align-items: center;
+        margin-bottom: 8px;
+    }
+    .components-circular-option-picker__option-wrapper .dashicon {
+        position: absolute;
+        left: 2px;
+        top: 2px;
+        border-radius: 50%;
+        z-index: 2;
+        pointer-events: none;
+        width: 24px;
+        height: 24px;
+        line-height: 24px;
     }
 }
 

--- a/src/controls/color/color-palette-control.js
+++ b/src/controls/color/color-palette-control.js
@@ -23,7 +23,7 @@ export default function ColorPalette( {
         return () => onChange( value === color ? undefined : color );
     }
     const customColorPickerLabel = __( 'Custom color picker', '@@text_domain' );
-    const classes = classnames( 'components-color-palette', className );
+    const classes = classnames( 'components-color-palette', 'components-circular-option-picker', className );
     return (
         <div className={ classes }>
             { map( colors, ( { color, name } ) => {
@@ -50,16 +50,16 @@ export default function ColorPalette( {
                                 aria-pressed={ value === color }
                             />
                         </Tooltip>
-                        { value === color && <Dashicon icon="saved" /> }
+                        { value === color && <Dashicon icon="saved" style={ { color: '#000000' === value ? '#ffffff' : '#000000' } } /> }
                     </div>
                 );
             } ) }
 
-            <div className="components-color-palette__custom-clear-wrapper">
+            <div className="components-color-palette__custom-clear-wrapper components-circular-option-picker__custom-clear-wrapper">
                 { ! disableCustomColors
                     && (
                         <Dropdown
-                            className="components-color-palette__custom-color"
+                            className="components-color-palette__custom-color components-circular-option-picker__dropdown-link-action"
                             contentClassName="components-color-palette__picker"
                             renderToggle={ ( { isOpen, onToggle } ) => (
                                 <Button


### PR DESCRIPTION
Made the color picker match the look of the Gutenberg color picker.

- Updated checkmark positioning
- Basic checkmark contrast
- Updated label bottom spacing
- Updated clear button & custom color spacing

**Old:**
![image](https://user-images.githubusercontent.com/747304/139923862-04ce2237-3820-4a39-a71e-1f23f453015f.png)

**New:**
![image](https://user-images.githubusercontent.com/747304/139923010-b8c04458-0ab2-407d-a008-4ea7c255ab4b.png)


**WordPress Color picker**
![image](https://user-images.githubusercontent.com/747304/139924044-d8a2e5f0-da2e-434e-815a-ad4db49a5728.png)

