### PR TITLE
Prevent propagating cut event to gutenberg (resolves #204)

### DIFF
--- a/src/assets/admin/components/code-editor/index.js
+++ b/src/assets/admin/components/code-editor/index.js
@@ -14,38 +14,61 @@ import 'ace-builds/src-noconflict/ext-language_tools';
 // Import CSS
 import './editor.scss';
 
-const { Component } = wp.element;
+const {
+    Component,
+    createRef,
+} = wp.element;
 
 export default class CodeEditor extends Component {
+    constructor( ...args ) {
+        super( ...args );
+
+        this.editorWrapper = createRef();
+    }
+
+    componentDidMount() {
+        this.editorWrapper.current.addEventListener( 'cut', this.handleCut );
+    }
+
+    componentWillUnmount() {
+        this.editorWrapper.current.removeEventListener( 'cut', this.handleCut );
+    }
+
+    handleCut = ( event ) => {
+        event.stopPropagation();
+    };
+
     render() {
         return (
-            <AceEditor
-                theme="textmate"
-                onLoad={ ( editor ) => {
-                    editor.renderer.setScrollMargin( 16, 16, 16, 16 );
-                    editor.renderer.setPadding( 16 );
-                } }
-                fontSize={ 12 }
-                showPrintMargin
-                showGutter
-                highlightActiveLine={ false }
-                width="100%"
-                className="lazyblocks-component-code-editor"
-                { ...this.props }
-                editorProps={ {
-                    $blockScrolling: Infinity,
-                    ...this.props.editorProps || {},
-                } }
-                setOptions={ {
-                    enableBasicAutocompletion: true,
-                    enableLiveAutocompletion: true,
-                    enableSnippets: true,
-                    showLineNumbers: true,
-                    tabSize: 2,
-                    useWorker: false,
-                    ...this.props.setOptions || {},
-                } }
-            />
+            <div ref={ this.editorWrapper }>
+                <AceEditor
+                    theme="textmate"
+                    onLoad={ ( editor ) => {
+                        editor.renderer.setScrollMargin( 16, 16, 16, 16 );
+                        editor.renderer.setPadding( 16 );
+                    } }
+                    fontSize={ 12 }
+                    showPrintMargin
+                    showGutter
+                    highlightActiveLine={ false }
+                    width="100%"
+                    className="lazyblocks-component-code-editor"
+                    { ...this.props }
+                    editorProps={ {
+                        $blockScrolling: Infinity,
+                        ...this.props.editorProps || {},
+                    } }
+                    setOptions={ {
+                        enableBasicAutocompletion: true,
+                        enableLiveAutocompletion: true,
+                        enableSnippets: true,
+                        showLineNumbers: true,
+                        tabSize: 2,
+                        useWorker: false,
+                        ...this.props.setOptions || {},
+                    } }
+                />
+            </div>
         );
     }
 }


### PR DESCRIPTION
Ace editor seems to have a handler for copy and paste but not one for cut.
This commit prevents the propagation of the cut event from the CodeEditor component.