### PR TITLE
Update class-blocks.php

### DIFF
--- a/src/classes/class-blocks.php
+++ b/src/classes/class-blocks.php
@@ -1261,6 +1261,7 @@ class LazyBlocks_Blocks {
             $data = array(
                 'attributes'      => $attributes,
                 'render_callback' => array( $this, 'render_callback' ),
+                'example'         => array(),
             );
 
             // Register block type.


### PR DESCRIPTION
At the moment there is no Block inserter preview in Lazyblocks when you hover over the blocks in the Editor. This 1 line change let all of the lazyblocks having an inserter preview from (based on) the editor.php file of the Blocks. As per the docs: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#example-optional 
an empty example object - even if it is empty - triggers the preview to show. (see attached gif example).
![preview-example-for-lazyblocks](https://user-images.githubusercontent.com/29353679/147216309-8ffb5127-01a5-4fbc-b9ed-e2fe9dc64ba8.gif)
