### PR TITLE
fix help text will overlapping the input of any control

### DIFF
--- a/assets/components/base-control/editor.scss
+++ b/assets/components/base-control/editor.scss
@@ -8,8 +8,4 @@
     font-style: normal;
     color: rgb(117, 117, 117);
   }
-
-  .components-base-control + .lazyblocks-component-base-control__help {
-    margin-top: -16px;
-  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13030387/202526315-2da44f27-856d-4446-b8d0-e7a7dcb21b7b.png)
