### PR TITLE
Fix role capability sync lifecycle

### DIFF
--- a/classes/class-blocks.php
+++ b/classes/class-blocks.php
@@ -29,20 +29,6 @@ class LazyBlocks_Blocks {
 	private static $default_icon = null;
 
 	/**
-	 * Role capability sync option name.
-	 *
-	 * @var string
-	 */
-	const ROLE_CAPS_SYNC_OPTION = 'lzb_role_caps_version';
-
-	/**
-	 * Role capability sync version.
-	 *
-	 * @var string
-	 */
-	const ROLE_CAPS_SYNC_VERSION = '1';
-
-	/**
 	 * Cache hash for current request (includes controls and filter callbacks).
 	 *
 	 * @var string|null
@@ -358,25 +344,9 @@ class LazyBlocks_Blocks {
 	}
 
 	/**
-	 * Synchronize Lazy Blocks capabilities once per sync version.
-	 *
-	 * @return bool
-	 */
-	public function maybe_sync_role_caps() {
-		if ( self::ROLE_CAPS_SYNC_VERSION === get_option( self::ROLE_CAPS_SYNC_OPTION ) ) {
-			return false;
-		}
-
-		$this->sync_role_caps();
-		update_option( self::ROLE_CAPS_SYNC_OPTION, self::ROLE_CAPS_SYNC_VERSION );
-
-		return true;
-	}
-
-	/**
 	 * Add Roles
 	 *
-	 * @deprecated Use maybe_sync_role_caps() or sync_role_caps().
+	 * @deprecated Use sync_role_caps().
 	 *
 	 * @return void
 	 */

--- a/classes/class-blocks.php
+++ b/classes/class-blocks.php
@@ -29,6 +29,20 @@ class LazyBlocks_Blocks {
 	private static $default_icon = null;
 
 	/**
+	 * Role capability sync option name.
+	 *
+	 * @var string
+	 */
+	const ROLE_CAPS_SYNC_OPTION = 'lzb_role_caps_version';
+
+	/**
+	 * Role capability sync version.
+	 *
+	 * @var string
+	 */
+	const ROLE_CAPS_SYNC_VERSION = '1';
+
+	/**
 	 * Cache hash for current request (includes controls and filter callbacks).
 	 *
 	 * @var string|null
@@ -78,9 +92,6 @@ class LazyBlocks_Blocks {
 		// It is important to have priority higher than 10 to prevent possible conflicts.
 		// https://github.com/nk-crew/lazy-blocks/issues/247 .
 		add_filter( 'allowed_block_types_all', array( $this, 'allowed_block_types_all' ), 100, 2 );
-
-		// Custom post roles.
-		add_action( 'admin_init', array( $this, 'add_role_caps' ) );
 
 		// Additional elements in blocks list table.
 		add_filter( 'display_post_states', array( $this, 'display_post_states' ), 10, 2 );
@@ -296,30 +307,81 @@ class LazyBlocks_Blocks {
 	}
 
 	/**
+	 * Get the Lazy Blocks role capability matrix.
+	 *
+	 * @return array
+	 */
+	public function get_role_caps_matrix() {
+		return array(
+			'administrator' => array(
+				'edit_lazyblock',
+				'edit_lazyblocks',
+				'edit_other_lazyblocks',
+				'publish_lazyblocks',
+				'read_lazyblock',
+				'read_private_lazyblocks',
+				'delete_lazyblocks',
+				'delete_lazyblock',
+			),
+			'editor'        => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+			'author'        => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+			'contributor'   => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+		);
+	}
+
+	/**
+	 * Synchronize Lazy Blocks capabilities for built-in roles.
+	 *
+	 * @return void
+	 */
+	public function sync_role_caps() {
+		foreach ( $this->get_role_caps_matrix() as $role_name => $caps ) {
+			$role = get_role( $role_name );
+
+			if ( ! $role ) {
+				continue;
+			}
+
+			foreach ( $caps as $capability ) {
+				$role->add_cap( $capability );
+			}
+		}
+	}
+
+	/**
+	 * Synchronize Lazy Blocks capabilities once per sync version.
+	 *
+	 * @return bool
+	 */
+	public function maybe_sync_role_caps() {
+		if ( self::ROLE_CAPS_SYNC_VERSION === get_option( self::ROLE_CAPS_SYNC_OPTION ) ) {
+			return false;
+		}
+
+		$this->sync_role_caps();
+		update_option( self::ROLE_CAPS_SYNC_OPTION, self::ROLE_CAPS_SYNC_VERSION );
+
+		return true;
+	}
+
+	/**
 	 * Add Roles
+	 *
+	 * @deprecated Use maybe_sync_role_caps() or sync_role_caps().
+	 *
+	 * @return void
 	 */
 	public function add_role_caps() {
-		global $wp_roles;
-
-		if ( isset( $wp_roles ) ) {
-			$wp_roles->add_cap( 'administrator', 'edit_lazyblock' );
-			$wp_roles->add_cap( 'administrator', 'edit_lazyblocks' );
-			$wp_roles->add_cap( 'administrator', 'edit_other_lazyblocks' );
-			$wp_roles->add_cap( 'administrator', 'publish_lazyblocks' );
-			$wp_roles->add_cap( 'administrator', 'read_lazyblock' );
-			$wp_roles->add_cap( 'administrator', 'read_private_lazyblocks' );
-			$wp_roles->add_cap( 'administrator', 'delete_lazyblocks' );
-			$wp_roles->add_cap( 'administrator', 'delete_lazyblock' );
-
-			$wp_roles->add_cap( 'editor', 'read_lazyblock' );
-			$wp_roles->add_cap( 'editor', 'read_private_lazyblocks' );
-
-			$wp_roles->add_cap( 'author', 'read_lazyblock' );
-			$wp_roles->add_cap( 'author', 'read_private_lazyblocks' );
-
-			$wp_roles->add_cap( 'contributor', 'read_lazyblock' );
-			$wp_roles->add_cap( 'contributor', 'read_private_lazyblocks' );
-		}
+		$this->sync_role_caps();
 	}
 
 	/**

--- a/classes/class-migration.php
+++ b/classes/class-migration.php
@@ -35,10 +35,6 @@ class LazyBlocks_Migration {
 	 * Init.
 	 */
 	public function init() {
-		if ( function_exists( 'lazyblocks' ) && lazyblocks()->blocks() ) {
-			lazyblocks()->blocks()->maybe_sync_role_caps();
-		}
-
 		// Migration code added after `$this->initial_version` plugin version.
 		$saved_version   = get_option( 'lzb_db_version', $this->initial_version );
 		$current_version = LAZY_BLOCKS_VERSION;
@@ -62,6 +58,10 @@ class LazyBlocks_Migration {
 	public function get_migrations() {
 		return array(
 			array(
+				'version' => '4.3.0',
+				'cb'      => array( $this, 'v_4_3_0_sync_role_caps' ),
+			),
+			array(
 				'version' => '2.5.0',
 				'cb'      => array( $this, 'v_2_5_0' ),
 			),
@@ -70,6 +70,17 @@ class LazyBlocks_Migration {
 				'cb'      => array( $this, 'v_2_1_0' ),
 			),
 		);
+	}
+
+	/**
+	 * Synchronize Lazy Blocks capabilities during the 4.3.0 upgrade path.
+	 *
+	 * @return void
+	 */
+	public function v_4_3_0_sync_role_caps() {
+		if ( function_exists( 'lazyblocks' ) && lazyblocks()->blocks() ) {
+			lazyblocks()->blocks()->sync_role_caps();
+		}
 	}
 
 	/**

--- a/classes/class-migration.php
+++ b/classes/class-migration.php
@@ -35,6 +35,10 @@ class LazyBlocks_Migration {
 	 * Init.
 	 */
 	public function init() {
+		if ( function_exists( 'lazyblocks' ) && lazyblocks()->blocks() ) {
+			lazyblocks()->blocks()->maybe_sync_role_caps();
+		}
+
 		// Migration code added after `$this->initial_version` plugin version.
 		$saved_version   = get_option( 'lzb_db_version', $this->initial_version );
 		$current_version = LAZY_BLOCKS_VERSION;

--- a/lazy-blocks.php
+++ b/lazy-blocks.php
@@ -119,6 +119,10 @@ if ( ! class_exists( 'LazyBlocks' ) ) :
 		 * Activation Hook
 		 */
 		public function activation_hook() {
+			if ( $this->blocks ) {
+				$this->blocks->maybe_sync_role_caps();
+			}
+
 			LazyBlocks_Dummy::add();
 		}
 

--- a/lazy-blocks.php
+++ b/lazy-blocks.php
@@ -120,7 +120,7 @@ if ( ! class_exists( 'LazyBlocks' ) ) :
 		 */
 		public function activation_hook() {
 			if ( $this->blocks ) {
-				$this->blocks->maybe_sync_role_caps();
+				$this->blocks->sync_role_caps();
 			}
 
 			LazyBlocks_Dummy::add();

--- a/tests/phpunit/CapabilitySyncTest.php
+++ b/tests/phpunit/CapabilitySyncTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Tests for Lazy Blocks role capability synchronization lifecycle.
+ */
+class CapabilitySyncTest extends WP_UnitTestCase {
+	/**
+	 * Original lzb_db_version option value.
+	 *
+	 * @var string
+	 */
+	private $original_db_version = '__missing__';
+
+	/**
+	 * Original role capability state before each test.
+	 *
+	 * @var array
+	 */
+	private $original_role_caps = array();
+
+	/**
+	 * Capability matrix expected for Lazy Blocks roles.
+	 *
+	 * @return array
+	 */
+	private function get_role_capability_matrix() {
+		return array(
+			'administrator' => array(
+				'edit_lazyblock',
+				'edit_lazyblocks',
+				'edit_other_lazyblocks',
+				'publish_lazyblocks',
+				'read_lazyblock',
+				'read_private_lazyblocks',
+				'delete_lazyblocks',
+				'delete_lazyblock',
+			),
+			'editor'        => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+			'author'        => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+			'contributor'   => array(
+				'read_lazyblock',
+				'read_private_lazyblocks',
+			),
+		);
+	}
+
+	/**
+	 * Capture the current role capability state so tests can restore it.
+	 */
+	private function capture_role_capabilities() {
+		foreach ( $this->get_role_capability_matrix() as $role_name => $caps ) {
+			$role = get_role( $role_name );
+
+			if ( ! $role ) {
+				continue;
+			}
+
+			foreach ( $caps as $capability ) {
+				$this->original_role_caps[ $role_name ][ $capability ] = $role->has_cap( $capability );
+			}
+		}
+	}
+
+	/**
+	 * Restore the role capability state captured before each test.
+	 */
+	private function restore_role_capabilities() {
+		foreach ( $this->original_role_caps as $role_name => $caps ) {
+			$role = get_role( $role_name );
+
+			if ( ! $role ) {
+				continue;
+			}
+
+			foreach ( $caps as $capability => $has_capability ) {
+				if ( $has_capability ) {
+					$role->add_cap( $capability );
+				} else {
+					$role->remove_cap( $capability );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Remove the Lazy Blocks capabilities from all affected roles.
+	 */
+	private function remove_lazyblocks_capabilities() {
+		foreach ( $this->get_role_capability_matrix() as $role_name => $caps ) {
+			$role = get_role( $role_name );
+
+			if ( ! $role ) {
+				continue;
+			}
+
+			foreach ( $caps as $capability ) {
+				$role->remove_cap( $capability );
+			}
+		}
+	}
+
+	/**
+	 * Assert the expected Lazy Blocks capability matrix is applied.
+	 */
+	private function assert_lazyblocks_capability_matrix_applied() {
+		foreach ( $this->get_role_capability_matrix() as $role_name => $caps ) {
+			$role = get_role( $role_name );
+
+			$this->assertNotNull( $role, sprintf( 'Role %s should exist.', $role_name ) );
+
+			foreach ( $caps as $capability ) {
+				$this->assertTrue(
+					$role->has_cap( $capability ),
+					sprintf( 'Role %s should have capability %s.', $role_name, $capability )
+				);
+			}
+		}
+	}
+
+	/**
+	 * Get a migration instance without registering its constructor hooks.
+	 *
+	 * @return LazyBlocks_Migration
+	 */
+	private function create_migration_instance() {
+		$reflection = new ReflectionClass( 'LazyBlocks_Migration' );
+
+		return $reflection->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Set up test state.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_db_version = get_option( 'lzb_db_version', '__missing__' );
+		$this->capture_role_capabilities();
+	}
+
+	/**
+	 * Restore test state.
+	 */
+	protected function tearDown(): void {
+		$this->restore_role_capabilities();
+
+		if ( '__missing__' === $this->original_db_version ) {
+			delete_option( 'lzb_db_version' );
+		} else {
+			update_option( 'lzb_db_version', $this->original_db_version );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Capabilities should not be synchronized via admin_init.
+	 */
+	public function test_role_caps_are_not_synced_on_admin_init() {
+		$this->assertFalse(
+			has_action( 'admin_init', array( lazyblocks()->blocks(), 'add_role_caps' ) ),
+			'Role capability sync should not be hooked to admin_init.'
+		);
+	}
+
+	/**
+	 * Existing installs should receive capabilities through the migration path.
+	 */
+	public function test_migration_syncs_role_caps_for_existing_installs() {
+		$this->remove_lazyblocks_capabilities();
+		update_option( 'lzb_db_version', '4.2.9' );
+
+		$migration = $this->create_migration_instance();
+		$migration->init();
+
+		$this->assert_lazyblocks_capability_matrix_applied();
+		$this->assertSame( LAZY_BLOCKS_VERSION, get_option( 'lzb_db_version' ) );
+	}
+
+	/**
+	 * Fresh installs should receive capabilities when migrations run for the first time.
+	 */
+	public function test_migration_syncs_role_caps_for_fresh_installs() {
+		$this->remove_lazyblocks_capabilities();
+		delete_option( 'lzb_db_version' );
+
+		$migration = $this->create_migration_instance();
+		$migration->init();
+
+		$this->assert_lazyblocks_capability_matrix_applied();
+		$this->assertSame( LAZY_BLOCKS_VERSION, get_option( 'lzb_db_version' ) );
+	}
+}

--- a/tests/phpunit/CapabilitySyncTest.php
+++ b/tests/phpunit/CapabilitySyncTest.php
@@ -195,4 +195,15 @@ class CapabilitySyncTest extends WP_UnitTestCase {
 		$this->assert_lazyblocks_capability_matrix_applied();
 		$this->assertSame( LAZY_BLOCKS_VERSION, get_option( 'lzb_db_version' ) );
 	}
+
+	/**
+	 * Fresh installs should receive capabilities during plugin activation.
+	 */
+	public function test_activation_hook_syncs_role_caps_for_fresh_installs() {
+		$this->remove_lazyblocks_capabilities();
+
+		lazyblocks()->activation_hook();
+
+		$this->assert_lazyblocks_capability_matrix_applied();
+	}
 }


### PR DESCRIPTION
Superseded by #375.

A clean replacement PR was opened from a fresh branch so the branch/PR history no longer includes the accidental .spec commit artifact.