### PR TITLE
Fix: Repeater renders empty when its value is authored as a raw array in block markup

### DIFF
--- a/controls/repeater/index.php
+++ b/controls/repeater/index.php
@@ -75,22 +75,14 @@ class LazyBlocks_Control_Repeater extends LazyBlocks_Control {
 			return $attribute_data;
 		}
 
-		// Allow both the URL-encoded JSON string (produced by the editor) and a raw
-		// array to pass block attribute schema validation.
+		// The editor serializes the value with `encodeURI( JSON.stringify( value ) )`, but the
+		// value may also be authored in the block markup as a raw JSON array. Both forms are
+		// handled by `filter_control_value()`, so both have to pass the schema validation in
+		// `WP_Block_Type::prepare_attributes_for_render()` — otherwise the array is dropped and
+		// replaced with the empty default, and the block renders empty on the front end.
 		//
-		// Repeater values are registered as `string` because the editor serializes them
-		// with `encodeURI( JSON.stringify( value ) )`. However, when a Repeater value is
-		// authored directly in the block markup as a JSON array
-		// (e.g. `{"my_repeater":[{"text":"a"}]}`), `WP_Block_Type::prepare_attributes_for_render()`
-		// runs it through `rest_validate_value_from_schema()`, the array fails the `string`
-		// check, and WordPress drops the attribute and falls back to the empty default. The
-		// block then renders empty on the front end even though `filter_control_value()`
-		// already handles the array form. Accepting both types keeps the encoded-string form
-		// and the default valid while letting the raw-array form reach the render callback.
-		//
-		// This is skipped for meta-backed controls: their value is resolved from post meta
-		// (not from the block markup) so the schema-validation issue does not apply, and
-		// `register_meta()` only accepts a single scalar `type`, not a union.
+		// Skipped for meta controls: their value comes from post meta, not from the block
+		// markup, and `register_meta()` accepts a single scalar type, not a union.
 		if ( ! isset( $attribute_data['source'] ) || 'meta' !== $attribute_data['source'] ) {
 			$attribute_data['type'] = array( 'string', 'array' );
 		}

--- a/controls/repeater/index.php
+++ b/controls/repeater/index.php
@@ -87,7 +87,13 @@ class LazyBlocks_Control_Repeater extends LazyBlocks_Control {
 		// block then renders empty on the front end even though `filter_control_value()`
 		// already handles the array form. Accepting both types keeps the encoded-string form
 		// and the default valid while letting the raw-array form reach the render callback.
-		$attribute_data['type'] = array( 'string', 'array' );
+		//
+		// This is skipped for meta-backed controls: their value is resolved from post meta
+		// (not from the block markup) so the schema-validation issue does not apply, and
+		// `register_meta()` only accepts a single scalar `type`, not a union.
+		if ( ! isset( $attribute_data['source'] ) || 'meta' !== $attribute_data['source'] ) {
+			$attribute_data['type'] = array( 'string', 'array' );
+		}
 
 		$attribute_data['default'] = rawurlencode( wp_json_encode( array() ) );
 

--- a/controls/repeater/index.php
+++ b/controls/repeater/index.php
@@ -75,6 +75,20 @@ class LazyBlocks_Control_Repeater extends LazyBlocks_Control {
 			return $attribute_data;
 		}
 
+		// Allow both the URL-encoded JSON string (produced by the editor) and a raw
+		// array to pass block attribute schema validation.
+		//
+		// Repeater values are registered as `string` because the editor serializes them
+		// with `encodeURI( JSON.stringify( value ) )`. However, when a Repeater value is
+		// authored directly in the block markup as a JSON array
+		// (e.g. `{"my_repeater":[{"text":"a"}]}`), `WP_Block_Type::prepare_attributes_for_render()`
+		// runs it through `rest_validate_value_from_schema()`, the array fails the `string`
+		// check, and WordPress drops the attribute and falls back to the empty default. The
+		// block then renders empty on the front end even though `filter_control_value()`
+		// already handles the array form. Accepting both types keeps the encoded-string form
+		// and the default valid while letting the raw-array form reach the render callback.
+		$attribute_data['type'] = array( 'string', 'array' );
+
 		$attribute_data['default'] = rawurlencode( wp_json_encode( array() ) );
 
 		return $attribute_data;

--- a/tests/phpunit/controls/RepeaterControlTest.php
+++ b/tests/phpunit/controls/RepeaterControlTest.php
@@ -95,10 +95,8 @@ class RepeaterControlTest extends WP_UnitTestCase {
 		);
 	}
 
-	// A Repeater value authored directly in the block markup as a raw JSON array must
-	// survive `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
-	// Before the schema accepted the `array` type, WordPress dropped the attribute and the
-	// block rendered empty.
+	// A Repeater value authored in the block markup as a raw JSON array must survive
+	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
 	public function test_raw_array_value() {
 		$this->register_repeater_block();
 
@@ -113,9 +111,7 @@ class RepeaterControlTest extends WP_UnitTestCase {
 		);
 	}
 
-	// A meta-backed Repeater must keep a single scalar type: `register_meta()` does not
-	// accept a `string`/`array` union, and its value is resolved from post meta rather than
-	// from the block markup, so the schema-validation widening must not apply here.
+	// A meta Repeater must keep a single scalar type, `register_meta()` does not accept a union.
 	public function test_meta_backed_repeater_keeps_scalar_type() {
 		$this->add_test_block( array(
 			'controls' => array(

--- a/tests/phpunit/controls/RepeaterControlTest.php
+++ b/tests/phpunit/controls/RepeaterControlTest.php
@@ -1,0 +1,115 @@
+<?php
+class RepeaterControlTest extends WP_UnitTestCase {
+	public function add_test_block( $attrs = array() ) {
+		$block_slug = 'lazyblock/test';
+
+		lazyblocks()->add_block( array_merge(
+			array(
+				'slug' => $block_slug,
+			),
+			$attrs
+		) );
+
+		lazyblocks()->blocks()->register_block_render();
+	}
+
+	public function remove_test_block() {
+		$block_slug = 'lazyblock/test';
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( $block_slug ) ) {
+			$registry->unregister( $block_slug );
+		}
+
+		lazyblocks()->blocks()->remove_block( $block_slug );
+	}
+
+	// Remove test block after each test.
+	public function tear_down() {
+		$this->remove_test_block();
+
+		parent::tear_down();
+	}
+
+	// Register a block gated on a Repeater control with a single text child control.
+	public function register_repeater_block() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_repeater' => array(
+					'type' => 'repeater',
+					'name' => 'my_repeater',
+					'placement' => 'content',
+				),
+				'control_text' => array(
+					'type' => 'text',
+					'name' => 'text',
+					'default' => '',
+					'child_of' => 'control_repeater',
+					'placement' => 'content',
+				),
+			),
+			'code' => array(
+				'frontend_callback' => function( $attributes ) {
+					echo 'is array: ' . ( is_array( $attributes['my_repeater'] ) ? 1 : 0 );
+
+					if ( ! empty( $attributes['my_repeater'] ) && is_array( $attributes['my_repeater'] ) ) {
+						foreach ( $attributes['my_repeater'] as $row ) {
+							echo ' text: ' . $row['text'];
+						}
+					}
+				},
+			),
+		) );
+	}
+
+	// The empty default (`%5B%5D`) should decode to an empty array, not break the render.
+	public function test_default_value() {
+		$this->register_repeater_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test /-->' )
+		);
+	}
+
+	// The URL-encoded JSON string form produced by the editor must keep working (no regression).
+	public function test_encoded_string_value() {
+		$this->register_repeater_block();
+
+		$encoded = rawurlencode( wp_json_encode( array(
+			array( 'text' => 'a' ),
+			array( 'text' => 'b' ),
+			array( 'text' => 'c' ),
+		) ) );
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' text: a' .
+				' text: b' .
+				' text: c' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_repeater":"' . $encoded . '"} /-->' )
+		);
+	}
+
+	// A Repeater value authored directly in the block markup as a raw JSON array must
+	// survive `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
+	// Before the schema accepted the `array` type, WordPress dropped the attribute and the
+	// block rendered empty.
+	public function test_raw_array_value() {
+		$this->register_repeater_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' text: a' .
+				' text: b' .
+				' text: c' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_repeater":[{"text":"a"},{"text":"b"},{"text":"c"}]} /-->' )
+		);
+	}
+}

--- a/tests/phpunit/controls/RepeaterControlTest.php
+++ b/tests/phpunit/controls/RepeaterControlTest.php
@@ -112,4 +112,25 @@ class RepeaterControlTest extends WP_UnitTestCase {
 			do_blocks( '<!-- wp:lazyblock/test {"my_repeater":[{"text":"a"},{"text":"b"},{"text":"c"}]} /-->' )
 		);
 	}
+
+	// A meta-backed Repeater must keep a single scalar type: `register_meta()` does not
+	// accept a `string`/`array` union, and its value is resolved from post meta rather than
+	// from the block markup, so the schema-validation widening must not apply here.
+	public function test_meta_backed_repeater_keeps_scalar_type() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_repeater' => array(
+					'type' => 'repeater',
+					'name' => 'my_repeater',
+					'save_in_meta' => 'true',
+					'placement' => 'content',
+				),
+			),
+		) );
+
+		$block           = lazyblocks()->blocks()->get_block( 'lazyblock/test' );
+		$meta_attributes = lazyblocks()->blocks()->prepare_block_meta_attributes( $block['controls'], '', $block );
+
+		$this->assertSame( 'string', $meta_attributes['my_repeater']['type'] );
+	}
 }


### PR DESCRIPTION
## Summary

A Repeater control renders **empty on the front end** when the block markup stores its value as a raw JSON array instead of the editor's URL-encoded JSON string. The value is silently dropped during rendering, not during storage.

Reported against Lazy Blocks Pro 4.3.1. The reporter framed it as "empty on newly-created posts" and suspected caching — that is a misattribution. There is no caching involved; the real trigger is the **serialization format** of the Repeater value in the block markup.

## Root cause

- The Repeater control is registered as a block attribute with `type => 'string'`, because the editor serializes the value with `encodeURI( JSON.stringify( value ) )` (see `controls/repeater/script.js`, `updateValue` filter). That encoded-string form validates fine.
- On the front end, `render_block()` → `new WP_Block()` → `WP_Block_Type::prepare_attributes_for_render()` validates every attribute via `rest_validate_value_from_schema()`. When the markup contains the Repeater value as a raw **array** (hand-authored or programmatically inserted content, e.g. `{"my_repeater":[{"text":"a"}]}`), it fails validation against `type: string`, so WordPress **drops the attribute and substitutes its default** (`%5B%5D` → empty array). The render callback then sees an empty repeater.
- `filter_control_value()` in the Repeater control already handles both the encoded-string and the array forms — but the array never reaches it, because WordPress strips it during schema validation first.
- The direct `block-render` REST endpoint is unaffected because it calls the render callback directly and bypasses `prepare_attributes_for_render()`, which is why the same attributes render correctly there.

## Fix

Widen the Repeater attribute schema to accept both `string` and `array`:

```php
$attribute_data['type'] = array( 'string', 'array' );
```

This lets the raw-array form survive schema validation and reach the render callback. The editor's encoded-string form and the empty default remain valid, so the change is fully backward compatible.

## Reproduction

1. Create a dynamic PHP block gated on a Repeater control `my_repeater` with a child text control, e.g. `if ( ! empty( $attributes['my_repeater'] ) && is_array( $attributes['my_repeater'] ) ) : ... endif;`.
2. Insert into a page: `<!-- wp:lazyblock/my-block {"my_repeater":[{"text":"a"},{"text":"b"},{"text":"c"}]} /-->`.
3. View the front end → repeater renders empty (before this fix).
4. Call the `block-render` REST endpoint with the same attributes → renders correctly, confirming the block logic is correct and the loss happens in the front-end parse/validate path.

## Tests

Adds `tests/phpunit/controls/RepeaterControlTest.php` covering:
- the empty default decodes to an empty array without breaking the render;
- the editor's encoded-string form still renders all rows (no regression);
- the raw-array form now renders all rows (the fix / regression guard).

> Note: the PHPUnit suite runs under `wp-env` (Docker), which was not available in the authoring environment, so the new tests were validated for syntax and coding standards locally and are expected to run in CI.

## Related

- #291 — GraphQL consumers hitting the same URL-encoded-string design; never addressed upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow schema change for repeater block attributes with regression tests; meta-backed controls are explicitly excluded from the union type.
> 
> **Overview**
> Fixes **front-end repeater output** when block markup stores repeater data as a raw JSON array instead of the editor’s URL-encoded JSON string. WordPress was validating the attribute as `string` only during `prepare_attributes_for_render()`, dropping the value and falling back to the empty default before the repeater’s value filter could decode it.
> 
> For **non–meta-backed** repeater controls, the prepared block attribute type is widened to **`string` and `array`**, so both serialization forms reach the render callback. **Meta-backed** repeaters are unchanged and still register as a single `string` type, since meta registration does not support a union and values do not come from block markup.
> 
> Adds **`RepeaterControlTest`** with `do_blocks()` coverage for empty default, encoded-string values (regression), raw-array markup (the fix), and meta attribute typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c41390069686f3e49f8a62b461e5652637e23b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->