### PR TITLE
fix: use getEntityRecords to prevent too many calls

### DIFF
--- a/controls/gallery/gallery-control.js
+++ b/controls/gallery/gallery-control.js
@@ -14,6 +14,9 @@ import useBlockControlProps from '../../assets/hooks/use-block-control-props';
 
 const ALLOWED_MEDIA_TYPES = ['image'];
 
+// The REST API limits the `per_page` argument to 100 items.
+const MAX_IMAGES_PER_REQUEST = 100;
+
 function GalleryControl(props) {
 	const {
 		label,
@@ -31,10 +34,14 @@ function GalleryControl(props) {
 		const preview = {};
 
 		if (value && value.length) {
-			const ids = [...new Set(value.map((img) => img.id))];
+			// Images may be stored without an ID (added by URL),
+			// such images can't be requested from the media library.
+			const ids = [
+				...new Set(value.map((img) => img.id).filter(Boolean)),
+			];
 
-			for (let i = 0; i < ids.length; i += 100) {
-				const chunk = ids.slice(i, i + 100);
+			for (let i = 0; i < ids.length; i += MAX_IMAGES_PER_REQUEST) {
+				const chunk = ids.slice(i, i + MAX_IMAGES_PER_REQUEST);
 
 				const mediaItems = getEntityRecords('postType', 'attachment', {
 					include: chunk,

--- a/controls/gallery/gallery-control.js
+++ b/controls/gallery/gallery-control.js
@@ -26,36 +26,39 @@ function GalleryControl(props) {
 	} = props;
 
 	const { mediaUpload, imagesPreviewData } = useSelect((select) => {
-		const { getEntityRecord } = select('core');
+		const { getEntityRecords } = select('core');
 
 		const preview = {};
 
-		if (value && Object.keys(value).length) {
-			value.forEach((img) => {
-				if (!preview[img.id]) {
-					const mediaImg =
-						getEntityRecord('postType', 'attachment', img.id) ||
-						false;
+		if (value && value.length) {
+			const ids = [...new Set(value.map((img) => img.id))];
 
-					if (mediaImg) {
-						preview[img.id] = {
-							alt: mediaImg.alt_text,
-							url: mediaImg.source_url,
-						};
+			for (let i = 0; i < ids.length; i += 100) {
+				const chunk = ids.slice(i, i + 100);
 
-						if (
-							mediaImg.media_details &&
-							mediaImg.media_details.sizes &&
-							mediaImg.media_details.sizes[previewSize]
-						) {
-							preview[img.id].url =
-								mediaImg.media_details.sizes[
-									previewSize
-								].source_url;
-						}
+				const mediaItems = getEntityRecords('postType', 'attachment', {
+					include: chunk,
+					per_page: chunk.length,
+				});
+
+				(mediaItems || []).forEach((mediaImg) => {
+					preview[mediaImg.id] = {
+						alt: mediaImg.alt_text,
+						url: mediaImg.source_url,
+					};
+
+					if (
+						mediaImg.media_details &&
+						mediaImg.media_details.sizes &&
+						mediaImg.media_details.sizes[previewSize]
+					) {
+						preview[mediaImg.id].url =
+							mediaImg.media_details.sizes[
+								previewSize
+							].source_url;
 					}
-				}
-			});
+				});
+			}
 		}
 
 		return {


### PR DESCRIPTION
### Summary

In wp-admin, when adding a Block with a lazyblock gallery control, the control exectues a call to `/wp-json/wp/v2/media/xxx?context=edit&_locale=user` via function `getEntityRecord` for every image added to the gallery.

As this call is async, it bootstraps a new DB Connection every time, the call arrives in the backend. This leads to too many open DB Connection on certain hostings.

### Fix

Use the function `getEntityRecords` which requests the data for up to 100 media files. Repeat this for more than 100 files.

### Reproduction

1. Create a block with a gallery control in it
2. Add this block on a page
3. Add 100 images
4. notice the calls failing with Error 500 (only if your hosting provider has a concurrent DB Connection limit)

Closes https://github.com/nk-crew/lazy-blocks/issues/376