### PR TITLE
chore(e2e): append the flaky reporter instead of replacing the list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 .phpunit.result.cache
 /artifacts
 /tests/e2e/artifacts
+/flaky-tests
 
 # The /.cache folder is needed for phpcs to cache results between runs, while other .cache folders must be ignored
 # It is not possible to re-include a file if a parent directory of that file is excluded

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@babel/preset-env": "^7.24.0",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.4.0",
+				"@nk-crew/plugin-toolkit": "^0.5.0",
 				"@playwright/test": "^1.45.3",
 				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 				"@wordpress/env": "^10.4.0",
@@ -3642,9 +3642,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.4.0.tgz",
-			"integrity": "sha512-8E6YBINwuU1dOdszPKNSoukA0b72lo7FPKuCuj1bW70iPuquILLzStLnZPQKDyJiR/2p22mNb+H200tU5jKYAw==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.0.tgz",
+			"integrity": "sha512-Tfnw/ZmzE7wcWMldBZ73K/fSvtIlZLqLPQuLTSy9yN1cdo/ApJOOilK3e1bvqLNo/uzxLTNHj1U4j4e/DJy3DQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@babel/preset-env": "^7.24.0",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.4.0",
+		"@nk-crew/plugin-toolkit": "^0.5.0",
 		"@playwright/test": "^1.45.3",
 		"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 		"@wordpress/env": "^10.4.0",

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -13,11 +13,7 @@ const config = defineConfig(
 			new URL('./config/global-setup.js', `file:${__filename}`).href
 		),
 		timeout: 100_000,
-		overrides: {
-			reporter: process.env.CI
-				? [['github'], ['./config/flaky-tests-reporter.js']]
-				: 'list',
-		},
+		reporters: ['./config/flaky-tests-reporter.js'],
 	})
 );
 


### PR DESCRIPTION
`overrides.reporter` replaces the package default outright, so this config had
to restate the CI/local ternary just to add one reporter. The same three lines
were duplicated across six repositories.

[plugin-toolkit 0.5.0](https://github.com/nk-crew/plugin-toolkit/releases/tag/v0.5.0)
adds a `reporters` option that appends to the defaults, so the split lives in
one place.

The caret range had to be bumped explicitly: `^0.4.0` only allows patch
upgrades on a 0.x version, so it would never have picked up 0.5.0.

### Behaviour change

Appended reporters apply to both branches, so the flaky reporter now runs
locally as well as under CI. It creates a `flaky-tests/` directory on every
run, which is why that path is now ignored.

### Verified

`tests/e2e/specs/initial-loading.spec.js` against the local environment:

- default — `list` output, 2 passed, plus `flaky-tests/` created by the flaky
  reporter
- `CI=1` — `::notice title=🎭 Playwright Run Summary::` from the github
  reporter, plus `flaky-tests/`