### PR TITLE
feat(gallery): limit control preview to a grid

### DIFF
--- a/assets/block-builder/boxes/selected-control-settings/editor.scss
+++ b/assets/block-builder/boxes/selected-control-settings/editor.scss
@@ -32,6 +32,29 @@
 	}
 }
 
+// grid setting, e.g. the gallery preview grid.
+.lzb-block-builder-controls-item-settings-grid {
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+
+	// Only the last control drops its bottom margin, which would misalign the
+	// inputs.
+	> .components-base-control {
+		flex: 1;
+		min-width: 0;
+		margin-bottom: 0;
+	}
+
+	// "×" between the two inputs.
+	> span {
+		display: flex;
+		align-items: center;
+		height: 40px;
+		color: $color_dark_lighten;
+	}
+}
+
 // type settings
 .lzb-block-builder-type__dropdown {
 	display: block;

--- a/assets/editor/index.scss
+++ b/assets/editor/index.scss
@@ -483,23 +483,38 @@
 		}
 	}
 
+	// The columns count comes from the `gallery` control, which either reads it
+	// from the control settings or measures the available width.
 	.lzb-gutenberg-gallery-item {
-		width: calc(12.5% - 10px);
+		width: calc(100% / var(--lzb-gallery-columns, 4) - 10px);
 		margin: 5px;
+		border-radius: 6px;
 
-		// width
-		@media (max-width: 1000px) {
-			width: calc(14.22% - 10px);
+		img {
+			border-radius: 6px;
 		}
-		@media (max-width: 900px) {
-			width: calc(16.66% - 10px);
-		}
-		@media (max-width: 800px) {
-			width: calc(25% - 10px);
+	}
+
+	// "+N" counter which replaces the images hidden from the preview.
+	.lzb-gutenberg-gallery-item-more {
+		background-color: #ececec;
+
+		> span {
+			position: absolute;
+			inset: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 0 2px;
+			overflow: hidden;
+			color: #959595;
+			font-size: 13px;
+			font-weight: 500;
+			line-height: 1;
 		}
 
-		.lzb-inspector-controls & {
-			width: calc(25% - 10px);
+		.lzb-inspector-controls & > span {
+			font-size: 11px;
 		}
 	}
 

--- a/controls/gallery/gallery-control.js
+++ b/controls/gallery/gallery-control.js
@@ -5,7 +5,8 @@
 import { MediaPlaceholder, MediaUpload } from '@wordpress/block-editor';
 import { Button, DropZone, Tooltip, withNotices } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { useLayoutEffect, useState } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
@@ -15,30 +16,163 @@ import useBlockControlProps from '../../assets/hooks/use-block-control-props';
 
 const ALLOWED_MEDIA_TYPES = ['image'];
 
-// The REST API limits the `per_page` argument to 100 items.
+// Only the visible images are requested, so this is reached with large preview
+// grids only. The REST API limits the `per_page` argument to 100 items.
 const MAX_IMAGES_PER_REQUEST = 100;
+
+// The control is just a preview, the gallery itself is edited in the media
+// modal, so we render a limited grid and count the rest in the last item.
+export const DEFAULT_PREVIEW_ROWS = 4;
+export const MAX_PREVIEW_ROWS = 20;
+export const MAX_PREVIEW_COLUMNS = 20;
+
+// Used when the columns count is calculated from the control width.
+const MIN_COLUMN_WIDTH = 62;
+const MIN_AUTO_COLUMNS = 2;
+const MAX_AUTO_COLUMNS = 8;
+
+const ITEM_GAP = 10;
+
+// Preview items are tiny, so there is no need to load anything sharper than
+// a retina item.
+const PREVIEW_PIXEL_RATIO = 2;
+
+/**
+ * Parse a setting which limits the preview grid.
+ *
+ * @param {string|number} value - raw setting value.
+ * @param {number}        max   - highest allowed value.
+ *
+ * @return {number} - sanitized value, 0 when the setting is not set.
+ */
+function parseLimit(value, max) {
+	const parsed = parseInt(value, 10);
+
+	if (Number.isNaN(parsed) || parsed < 1) {
+		return 0;
+	}
+
+	return Math.min(parsed, max);
+}
+
+/**
+ * Calculate the number of preview columns which fit the given container width.
+ *
+ * @param {number} width - container width in pixels.
+ *
+ * @return {number} - columns count, 0 when the width is not measured yet.
+ */
+function getAutoColumnsCount(width) {
+	if (!width) {
+		return 0;
+	}
+
+	return Math.min(
+		MAX_AUTO_COLUMNS,
+		Math.max(MIN_AUTO_COLUMNS, Math.floor(width / MIN_COLUMN_WIDTH))
+	);
+}
+
+/**
+ * Find the smallest registered image size which still looks sharp in a preview
+ * item, so the control never downloads a full size image.
+ *
+ * @param {Object} mediaImg - attachment record.
+ * @param {number} itemWidth - rendered preview item width in pixels.
+ *
+ * @return {string} - image URL.
+ */
+function getPreviewImageUrl(mediaImg, itemWidth) {
+	const sizes =
+		mediaImg.media_details && mediaImg.media_details.sizes
+			? Object.values(mediaImg.media_details.sizes).filter(
+					(size) => size && size.source_url && size.width
+				)
+			: [];
+
+	if (!sizes.length) {
+		return mediaImg.source_url;
+	}
+
+	const targetWidth = itemWidth * PREVIEW_PIXEL_RATIO;
+	const covering = sizes.filter((size) => size.width >= targetWidth);
+
+	const picked = covering.length
+		? covering.reduce((a, b) => (a.width < b.width ? a : b))
+		: sizes.reduce((a, b) => (a.width > b.width ? a : b));
+
+	return picked.source_url;
+}
 
 function GalleryControl(props) {
 	const {
 		label,
 		value,
-		previewSize,
+		previewRows,
+		previewColumns,
 		noticeOperations,
 		noticeUI,
 		controlProps,
 		onChange = () => {},
 	} = props;
 
+	const [galleryNode, setGalleryNode] = useState(null);
+	const [containerWidth, setContainerWidth] = useState(0);
+
+	useLayoutEffect(() => {
+		if (!galleryNode) {
+			return;
+		}
+
+		const measure = () => {
+			setContainerWidth(galleryNode.offsetWidth);
+		};
+
+		measure();
+
+		const observer = new ResizeObserver(measure);
+		observer.observe(galleryNode);
+
+		return () => observer.disconnect();
+	}, [galleryNode]);
+
+	const rows =
+		parseLimit(previewRows, MAX_PREVIEW_ROWS) || DEFAULT_PREVIEW_ROWS;
+	const columns =
+		parseLimit(previewColumns, MAX_PREVIEW_COLUMNS) ||
+		getAutoColumnsCount(containerWidth);
+
+	const images = value && value.length ? value : [];
+
+	// Nothing is rendered until the control is measured, which happens in a
+	// layout effect, before the browser paints. Bailing out early also keeps
+	// the media library request below limited to the visible images.
+	const previewLimit = containerWidth ? columns * rows : 0;
+	const hasHiddenImages = previewLimit > 0 && images.length > previewLimit;
+
+	// The last item is replaced with the "+N" counter.
+	const previewImages = images.slice(
+		0,
+		hasHiddenImages ? previewLimit - 1 : previewLimit
+	);
+	const hiddenImagesCount = hasHiddenImages
+		? images.length - previewImages.length
+		: 0;
+
+	// Items are laid out by `assets/editor/index.scss` using the columns count
+	// and a fixed gap.
+	const itemWidth = columns ? containerWidth / columns - ITEM_GAP : 0;
+
 	const { mediaUpload, imagesPreviewData } = useSelect((select) => {
 		const { getEntityRecords } = select('core');
 
 		const preview = {};
 
-		if (value && value.length) {
+		if (previewImages.length) {
 			// Images may be stored without an ID (added by URL),
 			// such images can't be requested from the media library.
 			const ids = [
-				...new Set(value.map((img) => img.id).filter(Boolean)),
+				...new Set(previewImages.map((img) => img.id).filter(Boolean)),
 			];
 
 			for (let i = 0; i < ids.length; i += MAX_IMAGES_PER_REQUEST) {
@@ -52,19 +186,8 @@ function GalleryControl(props) {
 				(mediaItems || []).forEach((mediaImg) => {
 					preview[mediaImg.id] = {
 						alt: mediaImg.alt_text,
-						url: mediaImg.source_url,
+						url: getPreviewImageUrl(mediaImg, itemWidth),
 					};
-
-					if (
-						mediaImg.media_details &&
-						mediaImg.media_details.sizes &&
-						mediaImg.media_details.sizes[previewSize]
-					) {
-						preview[mediaImg.id].url =
-							mediaImg.media_details.sizes[
-								previewSize
-							].source_url;
-					}
 				});
 			}
 		}
@@ -112,8 +235,10 @@ function GalleryControl(props) {
 					render={({ open }) => (
 						<div
 							className="lzb-gutenberg-gallery"
+							style={{ '--lzb-gallery-columns': columns || null }}
 							onClick={open}
 							role="presentation"
+							ref={setGalleryNode}
 						>
 							<DropZone
 								onFilesDrop={(files) => {
@@ -196,7 +321,7 @@ function GalleryControl(props) {
 									</Button>
 								</Tooltip>
 							</div>
-							{value.map((img) => (
+							{previewImages.map((img) => (
 								<div
 									className="lzb-gutenberg-gallery-item"
 									key={img.id || img.url}
@@ -212,6 +337,23 @@ function GalleryControl(props) {
 									)}
 								</div>
 							))}
+							{hiddenImagesCount > 0 ? (
+								<div
+									className="lzb-gutenberg-gallery-item lzb-gutenberg-gallery-item-more"
+									title={sprintf(
+										/* translators: %d: number of images which are not displayed in the preview. */
+										_n(
+											'%d more image',
+											'%d more images',
+											hiddenImagesCount,
+											'lazy-blocks'
+										),
+										hiddenImagesCount
+									)}
+								>
+									<span>+{hiddenImagesCount}</span>
+								</div>
+							) : null}
 						</div>
 					)}
 				/>

--- a/controls/gallery/index.php
+++ b/controls/gallery/index.php
@@ -26,7 +26,8 @@ class LazyBlocks_Control_Gallery extends LazyBlocks_Control {
 			'default_settings' => false,
 		);
 		$this->attributes   = array(
-			'preview_size' => 'medium',
+			'preview_rows'    => '',
+			'preview_columns' => '',
 		);
 
 		parent::__construct();

--- a/controls/gallery/script.js
+++ b/controls/gallery/script.js
@@ -3,15 +3,18 @@
  * WordPress dependencies.
  */
 
-import { PanelBody, SelectControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { BaseControl, PanelBody, TextControl } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies.
  */
-import GalleryControl from './gallery-control';
+import GalleryControl, {
+	DEFAULT_PREVIEW_ROWS,
+	MAX_PREVIEW_COLUMNS,
+	MAX_PREVIEW_ROWS,
+} from './gallery-control';
 
 /**
  * Control render in editor.
@@ -23,7 +26,8 @@ addFilter(
 		<GalleryControl
 			label={props.data.label}
 			help={props.data.help}
-			previewSize={props.data.preview_size}
+			previewRows={props.data.preview_rows}
+			previewColumns={props.data.preview_columns}
 			value={props.getValue()}
 			controlProps={props}
 			onChange={(val) => {
@@ -88,49 +92,47 @@ addFilter('lzb.editor.control.gallery.updateValue', 'lzb.editor', (value) => {
 function AdditionalAttributes(props) {
 	const { updateData, data } = props;
 
-	const { imageSizes, imageDimensions } = useSelect((select) => {
-		const { getSettings } = select('core/block-editor');
-		const editorSettings = getSettings();
-
-		return {
-			imageSizes: editorSettings.imageSizes || [
-				{
-					name: __('Medium', 'lazy-blocks'),
-					slug: 'medium',
-				},
-			],
-			imageDimensions: editorSettings.imageDimensions || {
-				medium: {
-					width: 300,
-					height: 300,
-				},
-			},
-		};
-	});
-
 	return (
 		<PanelBody>
-			<SelectControl
-				label={__('Preview Size', 'lazy-blocks')}
-				options={imageSizes.map((sizeData) => {
-					let sizeLabel = sizeData.name;
-
-					if (imageDimensions[sizeData.slug]) {
-						sizeLabel += ` (${
-							imageDimensions[sizeData.slug].width
-						} × ${imageDimensions[sizeData.slug].height})`;
-					}
-
-					return {
-						label: sizeLabel,
-						value: sizeData.slug,
-					};
-				})}
-				value={data.preview_size || 'medium'}
-				onChange={(value) => updateData({ preview_size: value })}
-				__next40pxDefaultSize
+			<BaseControl
+				id="lazyblocks-control-gallery-preview-grid"
+				label={__('Preview Grid', 'lazy-blocks')}
+				help={__(
+					'Images which do not fit the grid are replaced with a counter. Leave the columns empty to fit the control width.',
+					'lazy-blocks'
+				)}
 				__nextHasNoMarginBottom
-			/>
+			>
+				<div className="lzb-block-builder-controls-item-settings-grid">
+					<TextControl
+						type="number"
+						label={__('Columns', 'lazy-blocks')}
+						placeholder={__('Auto', 'lazy-blocks')}
+						min={1}
+						max={MAX_PREVIEW_COLUMNS}
+						value={data.preview_columns}
+						onChange={(value) =>
+							updateData({ preview_columns: value })
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<span aria-hidden="true">×</span>
+					<TextControl
+						type="number"
+						label={__('Rows', 'lazy-blocks')}
+						placeholder={DEFAULT_PREVIEW_ROWS}
+						min={1}
+						max={MAX_PREVIEW_ROWS}
+						value={data.preview_rows}
+						onChange={(value) =>
+							updateData({ preview_rows: value })
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</div>
+			</BaseControl>
 		</PanelBody>
 	);
 }


### PR DESCRIPTION
## Problem

The Gallery control rendered every selected image. A gallery with 40+ images pushed the rest of the block out of view, and every image triggered a media library record fetch — even though the control is only a preview, since editing happens in the media modal.

## What changed

**Bounded preview grid.** The control now renders `columns × rows` items and replaces the overflow with a `+N` counter in the last slot.

**Columns measured from the control, not the viewport.** The old CSS used `@media (max-width: …)` breakpoints to pick a column count. That keyed off window width and ignored how much room the control actually had — a narrow control in a wide window still got 8 columns. A `ResizeObserver` now measures the control itself, so content and inspector placements both behave.

**Fewer media requests.** Two separate causes of over-fetching:

1. Before measuring, `columns` was `0`, so the code fell back to rendering *all* images and fired a request for the full set, then a second one for the visible subset. Nothing renders until the control is measured now (still inside a layout effect, before paint, so no flash).
2. `preview_size` forced one registered size for every item regardless of how small it rendered.

Verified on a 43-image test post: exactly 3 requests with `per_page` 31 / 15 / 14, one per visible gallery, matching the rendered counts.

**`Preview Size` removed, replaced by automatic selection.** It appeared only in `index.php`, `script.js`, and the preview lookup — never in the PHP render path, so front-end output is unaffected. The size is now the smallest registered one that stays sharp at 2×. Measured: 55px and 72px items load `150x150`; 119px and 121px items load `300x300`. Previously everything pulled `medium` (300×300).

**New `Preview Grid` setting**, one panel with two joined inputs:

```
PREVIEW GRID
COLUMNS         ROWS
[ Auto    ]  ×  [ 4    ]
```

Columns empty means fit-to-width. Both clamped 1–20 — without a cap a block author could configure a 1000-item grid and reintroduce the fetch problem.

**Styling.** 6px radius on gallery items, `+N` tile flat `#ececec` with no shadow, text `#959595` at 13px in content / 11px in the inspector.

## Reviewer notes

- **Existing blocks keep an orphaned `preview_size` meta value.** It is now ignored. Harmless, but there is no migration — say if you want one.
- **The Image control still has its own `preview_size`** (`controls/image/script.js`). Left alone since this was scoped to the gallery, but the same argument applies to it.
- **`build/` is not included**, matching the most recent gallery commit (4cf644d). Run `npm run build` to try it.
- Preview Grid styles went into `assets/block-builder/boxes/selected-control-settings/editor.scss` rather than a new per-control stylesheet, since controls only register JS (no CSS) and that file already holds control-specific settings styling for the select/radio choices group.

## Testing

Verified in the editor against a seeded 43-image gallery across both placements and several configurations — content auto (8×4, `+12`), 2 rows (`+28`), 5 columns × 3 rows (`+29`), inspector auto (4×4, `+28`), inspector 2 columns (`+36`) — plus live reflow when the container is resized, and at 1440 / 900 / 700px viewports. Computed styles checked for radius, colors, and font sizes. biome, stylelint, and phpcs all pass. No existing tests cover the gallery control.