### PR TITLE
fix(media): accept Image, File and Gallery values authored as raw JSON in block markup

### DIFF
--- a/controls/file/index.php
+++ b/controls/file/index.php
@@ -29,6 +29,9 @@ class LazyBlocks_Control_File extends LazyBlocks_Control {
 			'allowed_mime_types' => array(),
 		);
 
+		// Filters.
+		add_filter( 'lzb/prepare_block_attribute', array( $this, 'filter_lzb_prepare_block_attribute' ), 10, 2 );
+
 		parent::__construct();
 	}
 
@@ -46,6 +49,39 @@ class LazyBlocks_Control_File extends LazyBlocks_Control {
 	 */
 	public function get_script_depends() {
 		return array( 'lazyblocks-control-file' );
+	}
+
+	/**
+	 * Filter block attribute.
+	 *
+	 * @param array $attribute_data - attribute data.
+	 * @param mixed $control - control data.
+	 *
+	 * @return array filtered attribute data.
+	 */
+	public function filter_lzb_prepare_block_attribute( $attribute_data, $control ) {
+		if (
+			! $control ||
+			! isset( $control['type'] ) ||
+			$this->name !== $control['type']
+		) {
+			return $attribute_data;
+		}
+
+		// The editor serializes the value with `encodeURI( JSON.stringify( value ) )`, but the
+		// value may also be authored in the block markup as a raw JSON object. Both forms are
+		// handled by `filter_control_value()`, so both have to pass the schema validation in
+		// `WP_Block_Type::prepare_attributes_for_render()` — otherwise the object is dropped and
+		// replaced with the default, and the block renders empty on the front end. The `object`
+		// type is what matches the associative array the block parser decodes the object into.
+		//
+		// Skipped for meta controls: their value comes from post meta, not from the block
+		// markup, and `register_meta()` accepts a single scalar type, not a union.
+		if ( ! isset( $attribute_data['source'] ) || 'meta' !== $attribute_data['source'] ) {
+			$attribute_data['type'] = array( 'string', 'object' );
+		}
+
+		return $attribute_data;
 	}
 
 	/**

--- a/controls/gallery/index.php
+++ b/controls/gallery/index.php
@@ -30,6 +30,9 @@ class LazyBlocks_Control_Gallery extends LazyBlocks_Control {
 			'preview_columns' => '',
 		);
 
+		// Filters.
+		add_filter( 'lzb/prepare_block_attribute', array( $this, 'filter_lzb_prepare_block_attribute' ), 10, 2 );
+
 		parent::__construct();
 	}
 
@@ -47,6 +50,38 @@ class LazyBlocks_Control_Gallery extends LazyBlocks_Control {
 	 */
 	public function get_script_depends() {
 		return array( 'lazyblocks-control-gallery' );
+	}
+
+	/**
+	 * Filter block attribute.
+	 *
+	 * @param array $attribute_data - attribute data.
+	 * @param mixed $control - control data.
+	 *
+	 * @return array filtered attribute data.
+	 */
+	public function filter_lzb_prepare_block_attribute( $attribute_data, $control ) {
+		if (
+			! $control ||
+			! isset( $control['type'] ) ||
+			$this->name !== $control['type']
+		) {
+			return $attribute_data;
+		}
+
+		// The editor serializes the value with `encodeURI( JSON.stringify( value ) )`, but the
+		// value may also be authored in the block markup as a raw JSON array of images. Both forms
+		// are handled by `filter_control_value()`, so both have to pass the schema validation in
+		// `WP_Block_Type::prepare_attributes_for_render()` — otherwise the array is dropped and
+		// replaced with the default, and the block renders empty on the front end.
+		//
+		// Skipped for meta controls: their value comes from post meta, not from the block
+		// markup, and `register_meta()` accepts a single scalar type, not a union.
+		if ( ! isset( $attribute_data['source'] ) || 'meta' !== $attribute_data['source'] ) {
+			$attribute_data['type'] = array( 'string', 'array' );
+		}
+
+		return $attribute_data;
 	}
 
 	/**

--- a/controls/image/index.php
+++ b/controls/image/index.php
@@ -30,6 +30,9 @@ class LazyBlocks_Control_Image extends LazyBlocks_Control {
 			'preview_size'    => 'medium',
 		);
 
+		// Filters.
+		add_filter( 'lzb/prepare_block_attribute', array( $this, 'filter_lzb_prepare_block_attribute' ), 10, 2 );
+
 		parent::__construct();
 	}
 
@@ -47,6 +50,39 @@ class LazyBlocks_Control_Image extends LazyBlocks_Control {
 	 */
 	public function get_script_depends() {
 		return array( 'lazyblocks-control-image' );
+	}
+
+	/**
+	 * Filter block attribute.
+	 *
+	 * @param array $attribute_data - attribute data.
+	 * @param mixed $control - control data.
+	 *
+	 * @return array filtered attribute data.
+	 */
+	public function filter_lzb_prepare_block_attribute( $attribute_data, $control ) {
+		if (
+			! $control ||
+			! isset( $control['type'] ) ||
+			$this->name !== $control['type']
+		) {
+			return $attribute_data;
+		}
+
+		// The editor serializes the value with `encodeURI( JSON.stringify( value ) )`, but the
+		// value may also be authored in the block markup as a raw JSON object. Both forms are
+		// handled by `filter_control_value()`, so both have to pass the schema validation in
+		// `WP_Block_Type::prepare_attributes_for_render()` — otherwise the object is dropped and
+		// replaced with the default, and the block renders empty on the front end. The `object`
+		// type is what matches the associative array the block parser decodes the object into.
+		//
+		// Skipped for meta controls: their value comes from post meta, not from the block
+		// markup, and `register_meta()` accepts a single scalar type, not a union.
+		if ( ! isset( $attribute_data['source'] ) || 'meta' !== $attribute_data['source'] ) {
+			$attribute_data['type'] = array( 'string', 'object' );
+		}
+
+		return $attribute_data;
 	}
 
 	/**

--- a/tests/phpunit/controls/FileControlTest.php
+++ b/tests/phpunit/controls/FileControlTest.php
@@ -1,0 +1,120 @@
+<?php
+class FileControlTest extends WP_UnitTestCase {
+	public function add_test_block( $attrs = array() ) {
+		$block_slug = 'lazyblock/test';
+
+		lazyblocks()->add_block( array_merge(
+			array(
+				'slug' => $block_slug,
+			),
+			$attrs
+		) );
+
+		lazyblocks()->blocks()->register_block_render();
+	}
+
+	public function remove_test_block() {
+		$block_slug = 'lazyblock/test';
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( $block_slug ) ) {
+			$registry->unregister( $block_slug );
+		}
+
+		lazyblocks()->blocks()->remove_block( $block_slug );
+	}
+
+	// Remove test block after each test.
+	public function tear_down() {
+		$this->remove_test_block();
+
+		parent::tear_down();
+	}
+
+	// Register a block gated on a single File control.
+	public function register_file_block() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_file' => array(
+					'type' => 'file',
+					'name' => 'my_file',
+					'placement' => 'content',
+				),
+			),
+			'code' => array(
+				'frontend_callback' => function( $attributes ) {
+					$value = $attributes['my_file'] ?? null;
+
+					echo 'is array: ' . ( is_array( $value ) ? 1 : 0 );
+
+					if ( ! empty( $value['url'] ) ) {
+						echo ' url: ' . $value['url'];
+					}
+				},
+			),
+		) );
+	}
+
+	// No value in the block markup should not break the render.
+	public function test_default_value() {
+		$this->register_file_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 0' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test /-->' )
+		);
+	}
+
+	// The URL-encoded JSON string form produced by the editor must keep working (no regression).
+	public function test_encoded_string_value() {
+		$this->register_file_block();
+
+		$encoded = rawurlencode( wp_json_encode( array(
+			'url'   => 'https://example.com/a.pdf',
+			'title' => 'A',
+		) ) );
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.pdf' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_file":"' . $encoded . '"} /-->' )
+		);
+	}
+
+	// A File value authored in the block markup as a raw JSON object must survive
+	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
+	public function test_raw_object_value() {
+		$this->register_file_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.pdf' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_file":{"url":"https://example.com/a.pdf","title":"A"}} /-->' )
+		);
+	}
+
+	// A meta File must keep a single scalar type, `register_meta()` does not accept a union.
+	public function test_meta_backed_file_keeps_scalar_type() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_file' => array(
+					'type' => 'file',
+					'name' => 'my_file',
+					'save_in_meta' => 'true',
+					'placement' => 'content',
+				),
+			),
+		) );
+
+		$block           = lazyblocks()->blocks()->get_block( 'lazyblock/test' );
+		$meta_attributes = lazyblocks()->blocks()->prepare_block_meta_attributes( $block['controls'], '', $block );
+
+		$this->assertSame( 'string', $meta_attributes['my_file']['type'] );
+	}
+}

--- a/tests/phpunit/controls/FileControlTest.php
+++ b/tests/phpunit/controls/FileControlTest.php
@@ -85,6 +85,19 @@ class FileControlTest extends WP_UnitTestCase {
 		);
 	}
 
+	// Removing the file in the editor stores an empty string (`onChange( '' )`), which must
+	// still pass the widened schema instead of being dropped.
+	public function test_empty_string_value() {
+		$this->register_file_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 0' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_file":""} /-->' )
+		);
+	}
+
 	// A File value authored in the block markup as a raw JSON object must survive
 	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
 	public function test_raw_object_value() {

--- a/tests/phpunit/controls/GalleryControlTest.php
+++ b/tests/phpunit/controls/GalleryControlTest.php
@@ -1,0 +1,124 @@
+<?php
+class GalleryControlTest extends WP_UnitTestCase {
+	public function add_test_block( $attrs = array() ) {
+		$block_slug = 'lazyblock/test';
+
+		lazyblocks()->add_block( array_merge(
+			array(
+				'slug' => $block_slug,
+			),
+			$attrs
+		) );
+
+		lazyblocks()->blocks()->register_block_render();
+	}
+
+	public function remove_test_block() {
+		$block_slug = 'lazyblock/test';
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( $block_slug ) ) {
+			$registry->unregister( $block_slug );
+		}
+
+		lazyblocks()->blocks()->remove_block( $block_slug );
+	}
+
+	// Remove test block after each test.
+	public function tear_down() {
+		$this->remove_test_block();
+
+		parent::tear_down();
+	}
+
+	// Register a block gated on a single Gallery control.
+	public function register_gallery_block() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_gallery' => array(
+					'type' => 'gallery',
+					'name' => 'my_gallery',
+					'placement' => 'content',
+				),
+			),
+			'code' => array(
+				'frontend_callback' => function( $attributes ) {
+					$value = $attributes['my_gallery'] ?? null;
+
+					echo 'is array: ' . ( is_array( $value ) ? 1 : 0 );
+
+					if ( ! empty( $value ) && is_array( $value ) ) {
+						foreach ( $value as $image ) {
+							echo ' url: ' . $image['url'];
+						}
+					}
+				},
+			),
+		) );
+	}
+
+	// No value in the block markup should not break the render.
+	public function test_default_value() {
+		$this->register_gallery_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 0' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test /-->' )
+		);
+	}
+
+	// The URL-encoded JSON string form produced by the editor must keep working (no regression).
+	public function test_encoded_string_value() {
+		$this->register_gallery_block();
+
+		$encoded = rawurlencode( wp_json_encode( array(
+			array( 'url' => 'https://example.com/a.jpg' ),
+			array( 'url' => 'https://example.com/b.jpg' ),
+		) ) );
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.jpg' .
+				' url: https://example.com/b.jpg' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_gallery":"' . $encoded . '"} /-->' )
+		);
+	}
+
+	// A Gallery value authored in the block markup as a raw JSON array must survive
+	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
+	public function test_raw_array_value() {
+		$this->register_gallery_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.jpg' .
+				' url: https://example.com/b.jpg' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_gallery":[{"url":"https://example.com/a.jpg"},{"url":"https://example.com/b.jpg"}]} /-->' )
+		);
+	}
+
+	// A meta Gallery must keep a single scalar type, `register_meta()` does not accept a union.
+	public function test_meta_backed_gallery_keeps_scalar_type() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_gallery' => array(
+					'type' => 'gallery',
+					'name' => 'my_gallery',
+					'save_in_meta' => 'true',
+					'placement' => 'content',
+				),
+			),
+		) );
+
+		$block           = lazyblocks()->blocks()->get_block( 'lazyblock/test' );
+		$meta_attributes = lazyblocks()->blocks()->prepare_block_meta_attributes( $block['controls'], '', $block );
+
+		$this->assertSame( 'string', $meta_attributes['my_gallery']['type'] );
+	}
+}

--- a/tests/phpunit/controls/GalleryControlTest.php
+++ b/tests/phpunit/controls/GalleryControlTest.php
@@ -88,6 +88,19 @@ class GalleryControlTest extends WP_UnitTestCase {
 		);
 	}
 
+	// Removing every image in the editor stores an encoded empty array (`onChange( [] )`), which
+	// must still pass the widened schema instead of being dropped.
+	public function test_empty_array_value() {
+		$this->register_gallery_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_gallery":"%5B%5D"} /-->' )
+		);
+	}
+
 	// A Gallery value authored in the block markup as a raw JSON array must survive
 	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
 	public function test_raw_array_value() {

--- a/tests/phpunit/controls/ImageControlTest.php
+++ b/tests/phpunit/controls/ImageControlTest.php
@@ -1,0 +1,120 @@
+<?php
+class ImageControlTest extends WP_UnitTestCase {
+	public function add_test_block( $attrs = array() ) {
+		$block_slug = 'lazyblock/test';
+
+		lazyblocks()->add_block( array_merge(
+			array(
+				'slug' => $block_slug,
+			),
+			$attrs
+		) );
+
+		lazyblocks()->blocks()->register_block_render();
+	}
+
+	public function remove_test_block() {
+		$block_slug = 'lazyblock/test';
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( $block_slug ) ) {
+			$registry->unregister( $block_slug );
+		}
+
+		lazyblocks()->blocks()->remove_block( $block_slug );
+	}
+
+	// Remove test block after each test.
+	public function tear_down() {
+		$this->remove_test_block();
+
+		parent::tear_down();
+	}
+
+	// Register a block gated on a single Image control.
+	public function register_image_block() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_image' => array(
+					'type' => 'image',
+					'name' => 'my_image',
+					'placement' => 'content',
+				),
+			),
+			'code' => array(
+				'frontend_callback' => function( $attributes ) {
+					$value = $attributes['my_image'] ?? null;
+
+					echo 'is array: ' . ( is_array( $value ) ? 1 : 0 );
+
+					if ( ! empty( $value['url'] ) ) {
+						echo ' url: ' . $value['url'];
+					}
+				},
+			),
+		) );
+	}
+
+	// No value in the block markup should not break the render.
+	public function test_default_value() {
+		$this->register_image_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 0' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test /-->' )
+		);
+	}
+
+	// The URL-encoded JSON string form produced by the editor must keep working (no regression).
+	public function test_encoded_string_value() {
+		$this->register_image_block();
+
+		$encoded = rawurlencode( wp_json_encode( array(
+			'url' => 'https://example.com/a.jpg',
+			'alt' => 'A',
+		) ) );
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.jpg' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_image":"' . $encoded . '"} /-->' )
+		);
+	}
+
+	// An Image value authored in the block markup as a raw JSON object must survive
+	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
+	public function test_raw_object_value() {
+		$this->register_image_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 1' .
+				' url: https://example.com/a.jpg' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_image":{"url":"https://example.com/a.jpg","alt":"A"}} /-->' )
+		);
+	}
+
+	// A meta Image must keep a single scalar type, `register_meta()` does not accept a union.
+	public function test_meta_backed_image_keeps_scalar_type() {
+		$this->add_test_block( array(
+			'controls' => array(
+				'control_image' => array(
+					'type' => 'image',
+					'name' => 'my_image',
+					'save_in_meta' => 'true',
+					'placement' => 'content',
+				),
+			),
+		) );
+
+		$block           = lazyblocks()->blocks()->get_block( 'lazyblock/test' );
+		$meta_attributes = lazyblocks()->blocks()->prepare_block_meta_attributes( $block['controls'], '', $block );
+
+		$this->assertSame( 'string', $meta_attributes['my_image']['type'] );
+	}
+}

--- a/tests/phpunit/controls/ImageControlTest.php
+++ b/tests/phpunit/controls/ImageControlTest.php
@@ -85,6 +85,19 @@ class ImageControlTest extends WP_UnitTestCase {
 		);
 	}
 
+	// Removing the image in the editor stores an empty string (`onChange( '' )`), which must
+	// still pass the widened schema instead of being dropped.
+	public function test_empty_string_value() {
+		$this->register_image_block();
+
+		$this->assertEquals(
+			'<div class="wp-block-lazyblock-test">' .
+				'is array: 0' .
+			'</div>',
+			do_blocks( '<!-- wp:lazyblock/test {"my_image":""} /-->' )
+		);
+	}
+
 	// An Image value authored in the block markup as a raw JSON object must survive
 	// `WP_Block_Type::prepare_attributes_for_render()` and reach the render callback.
 	public function test_raw_object_value() {


### PR DESCRIPTION
## The bug

The Image, File and Gallery controls register their block attribute with the schema type `string`, because the editor serializes the value via `encodeURI( JSON.stringify( value ) )`.

When such a value is authored **directly in the block markup as raw JSON** — e.g. `<!-- wp:lazyblock/test {"my_image":{"url":"https://example.com/a.jpg"}} /-->` — `WP_Block_Type::prepare_attributes_for_render()` validates it with `rest_validate_value_from_schema()`, it fails the `string` check, WordPress drops the attribute and substitutes the default, and the block renders empty on the front end. This happens even though `filter_control_value()` in each control already handles the decoded form perfectly well.

This is the same latent bug that was fixed for the Repeater control in #377 — these three controls share the identical `string`-schema / decode-in-`filter_control_value()` pattern.

## The fix

Each control gains a `filter_lzb_prepare_block_attribute()` that widens the attribute schema to a union type, mirroring `controls/repeater/index.php`:

| Control | Value shape | New schema type |
|---|---|---|
| Gallery | JSON array of image objects | `array( 'string', 'array' )` |
| Image | JSON object (single image) | `array( 'string', 'object' )` |
| File | JSON object (single file) | `array( 'string', 'object' )` |

**Why `object` and not `array` for Image and File.** The block parser decodes a JSON object into an associative PHP array. `rest_get_best_type_for_value()` maps the `object` type to `rest_is_object()`, which accepts associative arrays; `array` would map to `rest_is_array()`, which rejects them. So `object` is the type that actually matches what arrives.

File's value shape isn't obvious from the PHP alone — `controls/file/file-control.js` settles it: `onChange(file)` stores a single media object and the UI reads `value.title` / `value.url`. So it's an object like Image, not an array. Its `filter_control_value()` short-circuits on non-strings, which is already correct for a raw object: the parser has decoded it into exactly the associative array the render callback expects.

**Backward compatible.** The encoded-string form produced by the editor and the existing defaults both remain valid — the `string` member of the union covers them, and the new tests assert it.

**Meta-backed controls are skipped**, using the same guard as the Repeater fix: their value is resolved from post meta rather than from the block markup, so the validation issue does not apply, and `register_meta()` accepts a single scalar type, not a union.

## Tests

Three new files under `tests/phpunit/controls/`, modeled on `RepeaterControlTest.php`. Each covers four cases: the missing value, the encoded-string form (regression guard), the raw JSON form (the bug), and a meta-backed control keeping its scalar `string` type.

Verified empirically in both directions. Before the fix, exactly the three raw-value tests failed, each rendering the empty fallback:

```
1) FileControlTest::test_raw_object_value
2) GalleryControlTest::test_raw_array_value
3) ImageControlTest::test_raw_object_value

-'<div class="wp-block-lazyblock-test">is array: 1 url: https://example.com/a.jpg</div>'
+'<div class="wp-block-lazyblock-test">is array: 0</div>'
```

After the fix, `npm run test:unit:php` reports `OK (45 tests, 140 assertions)`, up from 33 tests with no regressions, and `npm run lint:php` is clean at `41 / 41`.

## Notes for the reviewer

- No production code path other than the attribute schema changes — `filter_control_value()` is untouched in all three controls.
- The PHPUnit config warnings about `processUniqueFiles` and `filter` that appear in the test output are pre-existing in `phpunit.xml.dist` and unrelated to this change.