### PR TITLE
feat(editor): add block preview extension filters

### DIFF
--- a/assets/components/preview-server-callback/render-block-content.js
+++ b/assets/components/preview-server-callback/render-block-content.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies.
@@ -172,6 +173,23 @@ export default function RenderBlockContent({
 
 		const options = {
 			replace(domNode) {
+				// Allow 3rd-party code to replace custom components in the block markup.
+				const customNode = applyFilters(
+					'lzb.editor.PreviewServerCallback.replaceNode',
+					null,
+					domNode,
+					{
+						props,
+						parserOptions: options,
+						domToReact,
+						prepareAttributes,
+					}
+				);
+
+				if (customNode) {
+					return customNode;
+				}
+
 				// Replace the `innerblocks` component to proper output.
 				if (
 					domNode.name === 'InnerBlocks' ||

--- a/assets/editor/blocks/main/edit.js
+++ b/assets/editor/blocks/main/edit.js
@@ -13,6 +13,7 @@ import { useThrottle } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 /**
  * WordPress dependencies.
  */
@@ -314,6 +315,13 @@ export default function BlockEdit(props) {
 		attsForRender[attr] = attributes[attr];
 	});
 
+	// Allow 3rd-party code to add attributes, which are not registered as controls.
+	const filteredAttsForRender = applyFilters(
+		'lzb.editor.BlockEdit.attributesForRender',
+		attsForRender,
+		{ attributes, meta, lazyBlockData, props }
+	);
+
 	// show code preview
 	let showPreview = true;
 
@@ -419,7 +427,7 @@ export default function BlockEdit(props) {
 				<PreviewServerCallback
 					block={lazyBlockData.slug}
 					clientId={clientId}
-					attributes={attsForRender}
+					attributes={filteredAttsForRender}
 					context={context}
 					withBlockProps
 				/>
@@ -471,7 +479,7 @@ export default function BlockEdit(props) {
 						<PreviewServerCallback
 							block={lazyBlockData.slug}
 							clientId={clientId}
-							attributes={attsForRender}
+							attributes={filteredAttsForRender}
 							context={context}
 						/>
 					</div>

--- a/tests/e2e/utils/create-block.js
+++ b/tests/e2e/utils/create-block.js
@@ -5,6 +5,7 @@ export async function createBlock({
 	description,
 	code,
 	codeSingleOutput,
+	controls,
 }) {
 	const block = await requestUtils.rest({
 		path: '/wp/v2/lazyblocks',
@@ -30,6 +31,7 @@ export async function createBlock({
 				description: description || '',
 				code_single_output: codeSingleOutput ? 'true' : 'false',
 				code_frontend_html: code || '',
+				...(controls ? { controls } : {}),
 			},
 		},
 	});


### PR DESCRIPTION
Two extension points needed by the Pro `<RichText />` component (LZB-66). No behaviour change on its own — both filters are no-ops until something hooks them.

## `lzb.editor.PreviewServerCallback.replaceNode`

`assets/components/preview-server-callback/render-block-content.js`

Runs first in the parser's `replace` chain, before the built-in `InnerBlocks` / `useBlockProps` / `script` branches. Returning a node replaces the DOM node, returning a falsy value falls through to the existing behaviour.

The context argument carries what an external component needs and cannot import from this bundle:

- `props` — `PreviewServerCallback` props (`block` slug, `clientId`, `attributes`, `context`)
- `parserOptions` + `domToReact` — to reproduce the self-closing tag workaround already used for `<InnerBlocks />`
- `prepareAttributes` — the module-private attribute normaliser

## `lzb.editor.BlockEdit.attributesForRender`

`assets/editor/blocks/main/edit.js`

`attsForRender` is built only from the block controls, so an attribute registered outside of a control never reaches the server preview render. The filter runs after the reserved attributes are added, and the result is passed to both `PreviewServerCallback` calls.

## Also

`tests/e2e/utils/create-block.js` accepts `controls`, so specs can create a block with controls in one REST call instead of driving the builder UI.

## Testing

`npm run lint` and the editor e2e specs that cover the preview parser pass:

- `editor-block-component-inner-blocks`
- `editor-block-attribute-useBlockProps`
- `editor-block-rendering`

Refs LZB-66