### PR TITLE
chore(git): collapse generated output in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,12 @@
 *.svg   text eol=lf
 *.txt   text eol=lf
 *.yml   text eol=lf
+
+# Generated build output. Hidden in pull request diffs and excluded from the
+# language statistics — rebuild it with `npm run build`, never edit by hand.
+build/**          -diff linguist-generated=true
+languages/*.pot   linguist-generated=true
+languages/*.json  linguist-generated=true
+
+# Third-party code, excluded from the language statistics.
+vendors/**        linguist-vendored=true


### PR DESCRIPTION
## Why

Build output is minified, so every file is one very long line. Change a
character in a source file and git honestly reports `1 insertion, 1 deletion`
per built file — but GitHub renders that line as an unreadable blob, and the
pull request picks up a handful of extra files to scroll past and mark as
viewed.

The problem is not that the diff is big. It is that it is unreadable, and it
buries the few lines that actually need review.

## What changed

`.gitattributes` now marks the generated paths:

- **`linguist-generated=true`** — GitHub hides these files by default in pull
  request diffs (collapsed behind *Load diff*) and drops them from the
  repository language statistics.
- **`-diff`** — git prints `Binary files ... differ` locally instead of the
  blob. This affects diff rendering only; merges are unaffected, since the
  merge driver is a separate attribute.

Vendored third-party code is marked `linguist-vendored=true` in the same pass
where such code is committed.

## What does not change

Nothing in the build, the release packaging, or CI. `.gitattributes` only
affects how diffs are rendered and how GitHub counts languages. Every file
stays tracked exactly as before, and `git diff --exit-code` still detects
changes in them.

## Verification

`git check-attr diff linguist-generated linguist-vendored` was run against real
tracked paths in this repository: the patterns match the generated and vendored
files, and every source file resolves to `unspecified`.

---

Part of a pass across the plugin repositories.
