### PR TITLE
fix(e2e): drive the login helper with Playwright, not Puppeteer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@babel/preset-env": "^7.24.0",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.5.0",
+				"@nk-crew/plugin-toolkit": "^0.5.1",
 				"@playwright/test": "^1.45.3",
 				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 				"@wordpress/env": "^10.4.0",
@@ -3642,9 +3642,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.0.tgz",
-			"integrity": "sha512-Tfnw/ZmzE7wcWMldBZ73K/fSvtIlZLqLPQuLTSy9yN1cdo/ApJOOilK3e1bvqLNo/uzxLTNHj1U4j4e/DJy3DQ==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.1.tgz",
+			"integrity": "sha512-NMNVIZKcwQ6oRu6mSEjpOcme72s6n7f+nzRk9c+rinfjFnr1khB9tZJmLNrjBR1kE1l6FpArXLOWm4nvtZ6Ivg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@babel/preset-env": "^7.24.0",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.5.0",
+		"@nk-crew/plugin-toolkit": "^0.5.1",
 		"@playwright/test": "^1.45.3",
 		"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 		"@wordpress/env": "^10.4.0",

--- a/tests/e2e/utils/user-management.js
+++ b/tests/e2e/utils/user-management.js
@@ -13,7 +13,7 @@ import {
 	TIMEOUTS,
 	WP_ADMIN_USER,
 } from './config.js';
-import { createURL, isCurrentURL, pressKeyWithModifier } from './helpers.js';
+import { createURL, isCurrentURL } from './helpers.js';
 
 /**
  * Creates a test user with the specified role.
@@ -92,28 +92,27 @@ export async function loginUser(
 		throw new Error('Page context is invalid, cannot perform login');
 	}
 
-	// Navigate to login page if not already there
+	// Navigate to login page if not already there. `goto` resolves on the
+	// navigation it started, so there is nothing extra to wait for.
 	if (!(await isCurrentURL(page, 'wp-login.php'))) {
-		const waitForLoginPageNavigation = page.waitForNavigation();
 		await page.goto(createURL('wp-login.php'));
-		await waitForLoginPageNavigation;
 	}
 
-	// Focus and clear username field, then type
-	await page.focus(SELECTORS.LOGIN_USERNAME);
-	await pressKeyWithModifier(page, 'primary', 'a');
-	await page.type(SELECTORS.LOGIN_USERNAME, username);
+	// `fill` clears the field before typing, which is what the select-all
+	// dance around `type` was for.
+	await page.fill(SELECTORS.LOGIN_USERNAME, username);
+	await page.fill(SELECTORS.LOGIN_PASSWORD, password);
 
-	// Focus and clear password field, then type
-	await page.focus(SELECTORS.LOGIN_PASSWORD);
-	await pressKeyWithModifier(page, 'primary', 'a');
-	await page.type(SELECTORS.LOGIN_PASSWORD, password);
+	await page.click(SELECTORS.LOGIN_SUBMIT);
 
-	// Submit login and wait for navigation (Gutenberg pattern)
-	await Promise.all([
-		page.click(SELECTORS.LOGIN_SUBMIT),
-		page.waitForNavigation({ waitUntil: 'networkidle0' }),
-	]);
+	// Not `waitForNavigation`: it has to be listening before the navigation it
+	// waits for begins, and the click above may well have finished first — in
+	// which case it waits for the *next* navigation, which never comes.
+	// `waitForURL` looks at where the page already is, so it cannot miss.
+	// A failed login stays on wp-login.php and fails here, as it should.
+	await page.waitForURL((url) => !url.pathname.endsWith('/wp-login.php'), {
+		timeout: TIMEOUTS.LONG,
+	});
 }
 
 /**
@@ -136,7 +135,7 @@ export async function logoutUser(page) {
 		await Promise.all([
 			page.hover(SELECTORS.ADMIN_BAR_USER_MENU),
 			page.waitForSelector(SELECTORS.ADMIN_BAR_LOGOUT, {
-				visible: true,
+				state: 'visible',
 				timeout: TIMEOUTS.SHORT,
 			}),
 		]);
@@ -157,7 +156,7 @@ export async function logoutUser(page) {
 
 	// Wait for login page to confirm logout
 	await page.waitForSelector(SELECTORS.LOGIN_FORM, {
-		visible: true,
+		state: 'visible',
 		timeout: TIMEOUTS.MEDIUM,
 	});
 }
@@ -194,7 +193,11 @@ export async function deleteTestUser(requestUtils, userId, reassign = true) {
  */
 export async function getCurrentUser(page) {
 	try {
-		const cookies = await page.cookies();
+		// `page.cookies()` is Puppeteer's; in Playwright cookies belong to the
+		// context. The old call threw, the catch below swallowed it, and this
+		// function always answered "nobody is logged in" — so both callers
+		// below logged in again every single time.
+		const cookies = await page.context().cookies();
 		const loginCookie = cookies.find((cookie) =>
 			cookie.name?.startsWith(COOKIE_PATTERNS.LOGGED_IN)
 		);


### PR DESCRIPTION
## The bug

`tests/e2e/utils/user-management.js` was written against Puppeteer's API and ported to Playwright without adjusting the parts that behave differently.

**`loginUser` could wait forever.**

```js
await Promise.all([
	page.click(SELECTORS.LOGIN_SUBMIT),
	page.waitForNavigation({ waitUntil: 'networkidle0' }),
]);
```

`waitForNavigation` has to be listening *before* the navigation it waits for begins. `Promise.all` evaluates its array left to right, so the click goes first — and when the redirect lands before the listener is attached, the helper waits for the *next* navigation, which never comes. Nothing bounds that wait: Playwright leaves `navigationTimeout` at `0`, so it runs until the per-test timeout, and then does it again on each retry.

This is what has been eating lazy-blocks-pro's CI, where these specs also run against the Pro build:

```
Error: page.waitForNavigation: Target page, context or browser has been closed
waiting for navigation until "networkidle"
   at loginUser (tests/e2e/utils/user-management.js:115)
   at switchUserToContributor (tests/e2e/utils/user-management.js:250)
   at export-permission-security.spec.js:233
```

25 tests finish in ~1.5 minutes; this one burned the full 20-minute budget and then passed on retry — `1 flaky, 25 passed (21.6m)`. In [one run](https://github.com/nk-crew/lazy-blocks-pro/actions/runs/31413831490) it missed twice: 41.3 minutes.

**`getCurrentUser` always said "nobody".** `page.cookies()` is Puppeteer's; in Playwright cookies live on the context. The call threw `TypeError` on every invocation, the surrounding `catch` turned that into `null`, and so `switchUserToAdmin` and `switchUserToContributor` performed a full UI login every time instead of short-circuiting the way their comments claim.

## The fix

- `waitForURL` instead of `waitForNavigation` — it reads where the page already is, so the race cannot happen. A failed login stays on `wp-login.php` and now fails there in 10s with a clear message.
- `fill` instead of `focus` + select-all + `type`; `fill` clears the field itself.
- `page.context().cookies()`, so user switching actually short-circuits.
- `state: 'visible'` instead of Puppeteer's `visible: true` in the two `waitForSelector` calls. Playwright silently drops unknown option keys and defaults to `'visible'` anyway, so this is intent made real rather than a behaviour change.

## Verified

`export-permission-security.spec.js` (the spec that hangs) run against a Pro build, which is the exact CI arrangement that fails:

```
✓ 1 Admin can create and export blocks (3.0s)
✓ 2 Permission verification - edit_lazyblocks required (431ms)
✓ 3 Unauthenticated users cannot export blocks (1.8s)
✓ 4 Contributor cannot export blocks (1.4s)
4 passed (8.6s)
```

The guardrail that stops the next stuck navigation from costing 20 minutes is nk-crew/plugin-toolkit#1.