### PR TITLE
test(e2e): fix flaky block builder specs

### DIFF
--- a/tests/e2e/specs/editor-block-base-controls.spec.js
+++ b/tests/e2e/specs/editor-block-base-controls.spec.js
@@ -3,6 +3,11 @@
  * WordPress dependencies
  */
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+import {
+	insertLazyBlock,
+	openBlockBuilder,
+	saveBlockBuilder,
+} from '../utils/block-builder';
 import { createBlock } from '../utils/create-block';
 import { createControl } from '../utils/create-control';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
@@ -30,21 +35,7 @@ test.describe('editor block with Base control', () => {
 			codeSingleOutput: true,
 		});
 
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page.locator(`#post-${blockID} .row-title`).click();
-
-		await page.waitForTimeout(500);
-
-		const closeModal = await page
-			.locator('.components-modal__header')
-			.getByRole('button', { name: 'Close' });
-
-		await page.waitForTimeout(500);
-
-		if (await closeModal.isVisible()) {
-			await closeModal.click();
-		}
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		// Generate Text control
 		await createControl({
@@ -83,9 +74,7 @@ test.describe('editor block with Base control', () => {
 		await editor.canvas.getByRole('option', { name: 'PHP' }).click();
 
 		// Publish post.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		return blockID;
 	}
@@ -119,7 +108,9 @@ test.describe('editor block with Base control', () => {
 
 		await admin.createNewPost();
 
-		await editor.insertBlock({
+		await insertLazyBlock({
+			page,
+			editor,
 			name: 'lazyblock/test-base-block',
 		});
 

--- a/tests/e2e/specs/editor-block-checkbox-multiple-save-in-meta.spec.js
+++ b/tests/e2e/specs/editor-block-checkbox-multiple-save-in-meta.spec.js
@@ -3,6 +3,11 @@
  * WordPress dependencies
  */
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+import {
+	insertLazyBlock,
+	openBlockBuilder,
+	saveBlockBuilder,
+} from '../utils/block-builder';
 import { createBlock } from '../utils/create-block';
 import { createControl } from '../utils/create-control';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
@@ -35,24 +40,7 @@ test.describe('editor block with Checkbox (allow multiple) + save in meta', () =
 			codeSingleOutput: true,
 		});
 
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page
-			.getByRole('link', { name: 'Test Checkbox Meta Block' })
-			.first()
-			.click();
-
-		await page.waitForTimeout(500);
-
-		const closeModal = await page
-			.locator('.components-modal__header')
-			.getByRole('button', { name: 'Close' });
-
-		await page.waitForTimeout(500);
-
-		if (await closeModal.isVisible()) {
-			await closeModal.click();
-		}
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		// Create Checkbox control with "Allow Multiple" and choices.
 		// Note: We cannot pass options to createControl here because the
@@ -91,7 +79,6 @@ test.describe('editor block with Checkbox (allow multiple) + save in meta', () =
 				}),
 			});
 		await saveInMetaPanel.scrollIntoViewIfNeeded();
-		await page.waitForTimeout(300);
 		await saveInMetaPanel.locator('input[type="checkbox"]').first().check();
 
 		// Set output method to PHP.
@@ -101,9 +88,7 @@ test.describe('editor block with Checkbox (allow multiple) + save in meta', () =
 		await editor.canvas.getByRole('option', { name: 'PHP' }).click();
 
 		// Publish / save the block.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		return blockID;
 	}
@@ -125,7 +110,9 @@ test.describe('editor block with Checkbox (allow multiple) + save in meta', () =
 		// Create a new post and insert the block.
 		await admin.createNewPost();
 
-		await editor.insertBlock({
+		await insertLazyBlock({
+			page,
+			editor,
 			name: 'lazyblock/test-checkbox-meta-block',
 		});
 

--- a/tests/e2e/specs/editor-block-repeater-control.spec.js
+++ b/tests/e2e/specs/editor-block-repeater-control.spec.js
@@ -3,6 +3,11 @@
  * WordPress dependencies
  */
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+import {
+	insertLazyBlock,
+	openBlockBuilder,
+	saveBlockBuilder,
+} from '../utils/block-builder';
 import { createBlock } from '../utils/create-block';
 import { createControl } from '../utils/create-control';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
@@ -30,21 +35,7 @@ test.describe('editor block with Repeater control', () => {
 			codeSingleOutput: true,
 		});
 
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page.locator(`#post-${blockID} .row-title`).click();
-
-		await page.waitForTimeout(500);
-
-		const closeModal = await page
-			.locator('.components-modal__header')
-			.getByRole('button', { name: 'Close' });
-
-		await page.waitForTimeout(500);
-
-		if (await closeModal.isVisible()) {
-			await closeModal.click();
-		}
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		// Create.
 		await createControl({
@@ -72,9 +63,7 @@ test.describe('editor block with Repeater control', () => {
 		await editor.canvas.getByRole('option', { name: 'PHP' }).click();
 
 		// Publish post.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		return blockID;
 	}
@@ -108,7 +97,9 @@ test.describe('editor block with Repeater control', () => {
 
 		await admin.createNewPost();
 
-		await editor.insertBlock({
+		await insertLazyBlock({
+			page,
+			editor,
 			name: 'lazyblock/test-repeater-block',
 		});
 
@@ -122,24 +113,25 @@ test.describe('editor block with Repeater control', () => {
 		await page.getByLabel('Text control nested in').click();
 		await page.getByLabel('Text control nested in').fill('Test Row 3');
 
-		// Editor render.
+		// Editor render. The preview is rendered by PHP behind a REST request,
+		// so give it the same budget as the other backend-rendered specs.
 		await expect(
 			editor.canvas
 				.locator('.wp-block-lazyblock-test-repeater-block')
 				.getByText('Test Row 1')
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 
 		await expect(
 			editor.canvas
 				.locator('.wp-block-lazyblock-test-repeater-block')
 				.getByText('Test Row 2')
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 
 		await expect(
 			editor.canvas
 				.locator('.wp-block-lazyblock-test-repeater-block')
 				.getByText('Test Row 3')
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 
 		// Publish.
 		await page

--- a/tests/e2e/specs/editor-block-with-frame.spec.js
+++ b/tests/e2e/specs/editor-block-with-frame.spec.js
@@ -2,6 +2,11 @@
  * WordPress dependencies
  */
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+import {
+	insertLazyBlock,
+	openBlockBuilder,
+	saveBlockBuilder,
+} from '../utils/block-builder';
 import { createBlock } from '../utils/create-block';
 import { createControl } from '../utils/create-control';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
@@ -26,9 +31,7 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Create control.
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page.locator(`#post-${blockID} .row-title`).click();
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		await createControl({
 			page,
@@ -39,22 +42,18 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Publish post.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		// Check block in editor.
 		await admin.createNewPost();
 
-		await editor.insertBlock({
-			name: 'lazyblock/test',
-		});
+		await insertLazyBlock({ page, editor, name: 'lazyblock/test' });
 
 		await expect(
 			editor.canvas
 				.locator('.lazyblock .lzb-content-title')
 				.filter({ hasText: 'Block with frame' })
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 	});
 
 	test('should render frame in editor when there are content and inspector control', async ({
@@ -72,9 +71,7 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Create control.
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page.locator(`#post-${blockID} .row-title`).click();
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		await createControl({
 			page,
@@ -85,22 +82,18 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Publish post.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		// Check block in editor.
 		await admin.createNewPost();
 
-		await editor.insertBlock({
-			name: 'lazyblock/test',
-		});
+		await insertLazyBlock({ page, editor, name: 'lazyblock/test' });
 
 		await expect(
 			editor.canvas
 				.locator('.lazyblock .lzb-content-title')
 				.filter({ hasText: 'Block with frame' })
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 	});
 
 	test('should not render frame in editor when there are only inspector control', async ({
@@ -118,9 +111,7 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Create control.
-		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		await page.locator(`#post-${blockID} .row-title`).click();
+		await openBlockBuilder({ page, editor, admin, blockID });
 
 		await createControl({
 			page,
@@ -130,22 +121,18 @@ test.describe('editor block with frame and content controls', () => {
 		});
 
 		// Publish post.
-		await page.locator('role=button[name="Save"i]').click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
+		await saveBlockBuilder({ page });
 
 		// Check block in editor.
 		await admin.createNewPost();
 
-		await editor.insertBlock({
-			name: 'lazyblock/test',
-		});
+		await insertLazyBlock({ page, editor, name: 'lazyblock/test' });
 
 		await expect(
 			editor.canvas.locator(
 				'.wp-block-lazyblock-test:text("Hello There")'
 			)
-		).toBeVisible();
+		).toBeVisible({ timeout: 15000 });
 
 		await expect(
 			editor.canvas

--- a/tests/e2e/utils/block-builder.js
+++ b/tests/e2e/utils/block-builder.js
@@ -1,0 +1,111 @@
+/**
+ * WordPress dependencies
+ */
+import { expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Opens an existing block in the block builder UI, ready to be edited.
+ *
+ * Navigating to an existing post is not the same as `admin.createNewPost()`:
+ * that helper turns the welcome guide off for us, a plain navigation does not.
+ * The guide renders a modal whose overlay covers the whole editor and swallows
+ * every click on the canvas, so the builder must be opened through here.
+ *
+ * @param {Object} options         Options.
+ * @param {Object} options.page    Playwright page.
+ * @param {Object} options.editor  Block editor utils.
+ * @param {Object} options.admin   Admin utils.
+ * @param {number} options.blockID ID of the block post to open.
+ */
+export async function openBlockBuilder({ page, editor, admin, blockID }) {
+	await admin.visitAdminPage('edit.php?post_type=lazyblocks');
+
+	await page.locator(`#post-${blockID} .row-title`).click();
+
+	// `click()` returns once the click is dispatched, not once the navigation it
+	// starts has finished. Settle on the editor before running anything in the
+	// page, or it runs against a context that is about to be destroyed.
+	await page.waitForURL(/post\.php/);
+
+	// The builder lives inside the editor canvas iframe and is mounted by the
+	// `lzb-block-builder/main` block, which the plugin inserts itself. Waiting
+	// for it also means the editor stores are up, ready for `setPreferences`.
+	await expect(editor.canvas.getByLabel('Add Control')).toBeVisible();
+
+	await editor.setPreferences('core/edit-post', {
+		welcomeGuide: false,
+		fullscreenMode: false,
+	});
+
+	// The preference unmounts the guide, but only once React has re-rendered.
+	// Wait for that rather than guessing at how long it takes: until the overlay
+	// is gone it swallows every click aimed at the canvas underneath it.
+	await expect(page.locator('.components-modal__screen-overlay')).toHaveCount(
+		0
+	);
+}
+
+/**
+ * Saves the block currently open in the block builder, and waits for its data
+ * to actually reach the database.
+ *
+ * The builder does not store controls with the post. It listens for the post
+ * save to finish and only then POSTs the block data to
+ * `/lazy-blocks/v1/update-block-data/` (see
+ * `assets/block-builder/plugin/index.js`). Nothing in the editor UI reflects
+ * that second request: the Save button is already disabled while it is still in
+ * flight. Navigating away on the button alone aborts the write, and the next
+ * page then registers the block without its controls — no frame, no inspector
+ * controls, no rendered output.
+ *
+ * @param {Object} options      Options.
+ * @param {Object} options.page Playwright page.
+ */
+export async function saveBlockBuilder({ page }) {
+	const saveButton = page.locator('role=button[name="Save"i]');
+
+	// Subscribe before the click, so a fast response cannot be missed.
+	const blockDataSaved = page.waitForResponse(
+		(response) =>
+			response.url().includes('update-block-data') &&
+			response.request().method() === 'POST'
+	);
+
+	await saveButton.click();
+
+	await expect(saveButton).toBeDisabled();
+
+	const response = await blockDataSaved;
+
+	expect(response.ok()).toBe(true);
+}
+
+/**
+ * Inserts a block registered by Lazy Blocks into the current post.
+ *
+ * `editor.insertBlock()` only waits for `wp.blocks` to exist, which happens
+ * before the Lazy Blocks bundle has run its `registerBlockType()` calls. Insert
+ * too early and the block is created as an unregistered one, which renders
+ * nothing and fails later on an unrelated-looking assertion.
+ *
+ * @param {Object} options        Options.
+ * @param {Object} options.page   Playwright page.
+ * @param {Object} options.editor Block editor utils.
+ * @param {string} options.name   Block name, e.g. `lazyblock/test`.
+ */
+export async function insertLazyBlock({ page, editor, name }) {
+	await expect
+		.poll(
+			() =>
+				page.evaluate(
+					(blockName) => !!window.wp?.blocks?.getBlockType(blockName),
+					name
+				),
+			{
+				message: `Block type "${name}" was never registered in the editor.`,
+			}
+		)
+		.toBe(true);
+
+	await editor.insertBlock({ name });
+}


### PR DESCRIPTION
## What

Four e2e specs failed intermittently on CI and locally, timing out on the rendered block inside the editor canvas iframe:

- `editor-block-with-frame.spec.js` (all three tests)
- `editor-block-base-controls.spec.js` — "should render Base block correctly"
- `editor-block-checkbox-multiple-save-in-meta.spec.js` — "should save and persist multiple checkbox values in meta"
- `editor-block-repeater-control.spec.js` — "should render Repeater block correctly"

They passed on retry, so they hid behind "flaky". Two real races were behind it. The `page.waitForTimeout(500)` calls these specs shared were papering over one of them.

## Root cause 1 — the Gutenberg welcome guide

`admin.createNewPost()` turns the welcome guide off for us. Navigating to an *existing* post does not. The guide's `.components-modal__screen-overlay` covers the whole editor and swallows every click aimed at the canvas.

Three specs guessed at when the modal would appear (`waitForTimeout(500)` → `if (closeModal.isVisible())`), and `editor-block-with-frame.spec.js` had no such dance at all. Run in isolation it failed 3/3 with:

```
<div class="components-modal__screen-overlay">…</div> intercepts pointer events
```

It only passed on CI when an earlier spec in the run happened to dismiss the guide first — exactly the ordering dependency that reads as flakiness.

## Root cause 2 — the block data save is a second, unawaited request

The builder does not store controls with the post. `assets/block-builder/plugin/index.js` watches for the post save to finish and *only then* POSTs the block data to `/lazy-blocks/v1/update-block-data/`.

Nothing in the editor UI reflects that second request — the Save button is already disabled while it is still in flight. So `await expect(Save).toBeDisabled()` followed by `admin.createNewPost()` could abort the write, and the next page then registered the block without its controls: no frame, no inspector controls, no rendered output.

Confirmed with a throwaway spec that delayed `update-block-data` by 3s: **3/3 failures** on the old `toBeDisabled()`-only assertion, with the reported message verbatim (`Timed out … toBeVisible()`, `<element(s) not found>`), and **3/3 passes** with the new wait. That spec is not part of this PR.

## The fix

New `tests/e2e/utils/block-builder.js` with three helpers:

| Helper | Replaces | Waits on |
|---|---|---|
| `openBlockBuilder` | the sleep + `isVisible()` modal dance | `welcomeGuide`/`fullscreenMode` off via `editor.setPreferences`, then overlay count → 0 |
| `saveBlockBuilder` | `click()` + `toBeDisabled()` | the `update-block-data` response, subscribed *before* the click, plus `response.ok()` |
| `insertLazyBlock` | `editor.insertBlock()` | polls `wp.blocks.getBlockType()` — `insertBlock` only waits for `wp.blocks` to exist, not for Lazy Blocks to have registered anything |

Editor-render assertions in the frame and repeater specs move from the implicit 5s to the 15s that the base-controls and checkbox specs already used for the same PHP-behind-REST preview. That is the direct source of the `Timed out 5000ms` symptom.

## Reviewer notes

- Writing `openBlockBuilder` surfaced a third race worth knowing about: `setPreferences` fired against a context destroyed by the in-flight navigation from the row-title click. `page.waitForURL` plus the canvas assertion before touching preferences fixes it.
- `insertLazyBlock` turns a future regression here from a mystery canvas timeout into a named failure: `Block type "…" was never registered in the editor.`
- No `waitForTimeout` remains anywhere under `tests/e2e/`.
- Test-only change — no plugin source touched.

## Verification

- Affected specs, `--repeat-each=5`: **40/40 passed**
- Full e2e suite: **26/26 passed**
- `npx biome check tests/e2e/` clean