### PR TITLE
feat(builder): add wizard template and WPML extension points

### DIFF
--- a/assets/block-builder/boxes/wizard/index.js
+++ b/assets/block-builder/boxes/wizard/index.js
@@ -9,7 +9,7 @@ import { useDispatch, useSelect, select as wpSelect } from '@wordpress/data';
 /**
  * WordPress dependencies.
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 /**
@@ -28,23 +28,32 @@ import { templates } from './templates';
 const { is_pro: isPro } = window.lazyblocksBlockBuilderData;
 
 export default function Wizard({ onClose }) {
-	// Filtered here and not at the module level, because the scripts adding
-	// their own templates may be loaded after this one.
-	const wizardTemplates = useMemo(
-		() => applyFilters('lzb.constructor.wizard.templates', templates),
-		[]
+	// Filtered on every render and not at the module level, because the scripts
+	// adding their own templates may run after this one.
+	const wizardTemplates = applyFilters(
+		'lzb.constructor.wizard.templates',
+		templates
 	);
 
+	// A filter may replace the whole collection, so nothing here can rely on a
+	// specific preset being present.
+	const firstTemplate = Object.keys(wizardTemplates)[0] || '';
+	const firstTemplateData = wizardTemplates[firstTemplate] || {};
+
 	const [step, setStep] = useState(1);
-	const [template, setTemplate] = useState('basic');
-	const [icon, setIcon] = useState(wizardTemplates.basic.blockIcon);
-	const [title, setTitle] = useState(wizardTemplates.basic.title);
-	const [slug, setSlug] = useState('basic-block');
-	const [category, setCategory] = useState('text');
+	const [template, setTemplate] = useState(firstTemplate);
+	const [icon, setIcon] = useState(firstTemplateData.blockIcon);
+	const [title, setTitle] = useState(firstTemplateData.title);
+	const [slug, setSlug] = useState(
+		firstTemplate ? `${firstTemplate}-block` : ''
+	);
+	const [category, setCategory] = useState(
+		firstTemplateData.category || 'text'
+	);
 	const [styles, setStyles] = useState([]);
-	const [keywords, setKeywords] = useState(wizardTemplates.basic.keywords);
+	const [keywords, setKeywords] = useState(firstTemplateData.keywords);
 	const [description, setDescription] = useState(
-		wizardTemplates.basic.description
+		firstTemplateData.description
 	);
 	const { updateBlockData, addControl } = useDispatch(
 		'lazy-blocks/block-data'
@@ -148,6 +157,14 @@ export default function Wizard({ onClose }) {
 	}
 
 	async function finishSetup() {
+		const templateData = wizardTemplates[template];
+
+		// Every preset may be filtered out, and then there is nothing to set up.
+		if (!templateData) {
+			onClose();
+			return;
+		}
+
 		setPostTitle(title);
 
 		const newData = {
@@ -160,16 +177,16 @@ export default function Wizard({ onClose }) {
 			code_single_output: true,
 		};
 
-		const finalStyles = wizardTemplates[template].style.replace(
+		const finalStyles = templateData.style.replace(
 			/__BLOCK_CLASSNAME__/g,
 			`.wp-block-lazyblock-${slug}`
 		);
 
 		if (isPro) {
-			newData.code_frontend_html = wizardTemplates[template].template;
+			newData.code_frontend_html = templateData.template;
 			newData.style_block = finalStyles;
 		} else {
-			newData.code_frontend_html = `${wizardTemplates[template].template}
+			newData.code_frontend_html = `${templateData.template}
 
 {{!
 	These inline styles created for example only.
@@ -181,7 +198,7 @@ ${finalStyles}
 </style>`;
 		}
 
-		await processControls(wizardTemplates[template].controls);
+		await processControls(templateData.controls);
 
 		updateBlockData(newData);
 		onClose();

--- a/assets/block-builder/boxes/wizard/index.js
+++ b/assets/block-builder/boxes/wizard/index.js
@@ -9,7 +9,8 @@ import { useDispatch, useSelect, select as wpSelect } from '@wordpress/data';
 /**
  * WordPress dependencies.
  */
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 /**
  * External dependencies.
@@ -27,15 +28,24 @@ import { templates } from './templates';
 const { is_pro: isPro } = window.lazyblocksBlockBuilderData;
 
 export default function Wizard({ onClose }) {
+	// Filtered here and not at the module level, because the scripts adding
+	// their own templates may be loaded after this one.
+	const wizardTemplates = useMemo(
+		() => applyFilters('lzb.constructor.wizard.templates', templates),
+		[]
+	);
+
 	const [step, setStep] = useState(1);
 	const [template, setTemplate] = useState('basic');
-	const [icon, setIcon] = useState(templates.basic.blockIcon);
-	const [title, setTitle] = useState(templates.basic.title);
+	const [icon, setIcon] = useState(wizardTemplates.basic.blockIcon);
+	const [title, setTitle] = useState(wizardTemplates.basic.title);
 	const [slug, setSlug] = useState('basic-block');
 	const [category, setCategory] = useState('text');
 	const [styles, setStyles] = useState([]);
-	const [keywords, setKeywords] = useState(templates.basic.keywords);
-	const [description, setDescription] = useState(templates.basic.description);
+	const [keywords, setKeywords] = useState(wizardTemplates.basic.keywords);
+	const [description, setDescription] = useState(
+		wizardTemplates.basic.description
+	);
 	const { updateBlockData, addControl } = useDispatch(
 		'lazy-blocks/block-data'
 	);
@@ -150,16 +160,16 @@ export default function Wizard({ onClose }) {
 			code_single_output: true,
 		};
 
-		const finalStyles = templates[template].style.replace(
+		const finalStyles = wizardTemplates[template].style.replace(
 			/__BLOCK_CLASSNAME__/g,
 			`.wp-block-lazyblock-${slug}`
 		);
 
 		if (isPro) {
-			newData.code_frontend_html = templates[template].template;
+			newData.code_frontend_html = wizardTemplates[template].template;
 			newData.style_block = finalStyles;
 		} else {
-			newData.code_frontend_html = `${templates[template].template}
+			newData.code_frontend_html = `${wizardTemplates[template].template}
 
 {{!
 	These inline styles created for example only.
@@ -171,7 +181,7 @@ ${finalStyles}
 </style>`;
 		}
 
-		await processControls(templates[template].controls);
+		await processControls(wizardTemplates[template].controls);
 
 		updateBlockData(newData);
 		onClose();
@@ -208,7 +218,7 @@ ${finalStyles}
 
 			{step === 1 && (
 				<div className="lzb-block-builder-wizard-step-templates">
-					{Object.keys(templates).map((k) => (
+					{Object.keys(wizardTemplates).map((k) => (
 						<Button
 							key={k}
 							onClick={(e) => {
@@ -216,13 +226,15 @@ ${finalStyles}
 
 								setTemplate(k);
 
-								setIcon(templates[k].blockIcon);
-								setCategory(templates[k].category);
-								setTitle(`${templates[k].title} Block`);
-								setKeywords(templates[k].keywords);
-								setDescription(templates[k].description);
-								generateSlug(`${templates[k].title} Block`);
-								setStyles(templates[k].styles || []);
+								setIcon(wizardTemplates[k].blockIcon);
+								setCategory(wizardTemplates[k].category);
+								setTitle(`${wizardTemplates[k].title} Block`);
+								setKeywords(wizardTemplates[k].keywords);
+								setDescription(wizardTemplates[k].description);
+								generateSlug(
+									`${wizardTemplates[k].title} Block`
+								);
+								setStyles(wizardTemplates[k].styles || []);
 							}}
 							className={classnames(
 								'lzb-block-builder-wizard-template',
@@ -230,8 +242,8 @@ ${finalStyles}
 									'lzb-block-builder-wizard-template-active'
 							)}
 						>
-							{templates[k].icon}
-							<span>{templates[k].title}</span>
+							{wizardTemplates[k].icon}
+							<span>{wizardTemplates[k].title}</span>
 						</Button>
 					))}
 				</div>

--- a/classes/class-wpml.php
+++ b/classes/class-wpml.php
@@ -90,6 +90,12 @@ class LazyBlocks_WPML {
 				$translated_controls = $this->get_translated_controls_data( $block['controls'] );
 			}
 
+			/**
+			 * Allow adding block attributes, which are not registered as controls.
+			 * Each item is a WPML config node, see `get_translated_controls_data()`.
+			 */
+			$translated_controls = apply_filters( 'lzb/wpml/translated_attributes', $translated_controls, $block );
+
 			if ( ! empty( $translated_controls ) ) {
 				$config['wpml-config']['gutenberg-blocks']['gutenberg-block'][] = array(
 					'value' => '',


### PR DESCRIPTION
Two extension points the Pro plugin needs to ship setup-wizard presets built on the `<RichText />` component. No behaviour change on its own — both are no-ops until something hooks them.

## `lzb.constructor.wizard.templates`

`assets/block-builder/boxes/wizard/index.js`

Filters the whole `templates` object, so a preset can be replaced, extended or removed wholesale — markup, controls, styles, icon and copy all live in that object.

It runs inside the component, wrapped in `useMemo`, rather than at the module level: the scripts hooking it are separate bundles with no guaranteed load order, and a module-level `applyFilters` would run before they register.

## `lzb/wpml/translated_attributes`

`classes/class-wpml.php`

`wpml_config_array()` collects translatable names from the block controls only, so an attribute registered outside of a control can never be translated. The filter runs per block, after the controls are collected, and takes the same WPML config node shape `get_translated_controls_data()` produces.

## Testing

`npm run lint` passes. The wizard still offers the four built-in presets and creates the same block for each — the filtered object is identical when nothing hooks it.

Needed by the `<RichText />` presets in the Pro plugin.