### PR TITLE
fix(e2e): stop the export security tests asserting nothing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,9 +165,9 @@ jobs:
       - name: Setup Node.js and install dependencies
         uses: ./.github/setup-node
 
-      - name: Npm build
-        run: npm run build
-
+      # No `npm run build` here. `lint:js` is `biome check`, and the shared
+      # Biome config excludes `**/build`; `lint:css` globs the `assets` sources
+      # directly. Neither reads a single file the build produces.
       - name: Running the lint
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@babel/preset-env": "^7.24.0",
 				"@babel/register": "^7.23.7",
 				"@biomejs/biome": "2.5.7",
-				"@nk-crew/plugin-toolkit": "^0.5.1",
+				"@nk-crew/plugin-toolkit": "^0.6.0",
 				"@playwright/test": "^1.45.3",
 				"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 				"@wordpress/env": "^10.4.0",
@@ -3642,9 +3642,9 @@
 			}
 		},
 		"node_modules/@nk-crew/plugin-toolkit": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.5.1.tgz",
-			"integrity": "sha512-NMNVIZKcwQ6oRu6mSEjpOcme72s6n7f+nzRk9c+rinfjFnr1khB9tZJmLNrjBR1kE1l6FpArXLOWm4nvtZ6Ivg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@nk-crew/plugin-toolkit/-/plugin-toolkit-0.6.0.tgz",
+			"integrity": "sha512-KU9IwgzP8JP9Ra4rlE9UI4OOn8JhHdmyMHhmWDq3DjfuFbIio+STRBlbmxVe/jLEsycESWBoHt1vdR1AH9b5mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@babel/preset-env": "^7.24.0",
 		"@babel/register": "^7.23.7",
 		"@biomejs/biome": "2.5.7",
-		"@nk-crew/plugin-toolkit": "^0.5.1",
+		"@nk-crew/plugin-toolkit": "^0.6.0",
 		"@playwright/test": "^1.45.3",
 		"@wordpress/e2e-test-utils-playwright": "^1.4.0",
 		"@wordpress/env": "^10.4.0",

--- a/tests/e2e/specs/editor-block-component-inner-blocks.spec.js
+++ b/tests/e2e/specs/editor-block-component-inner-blocks.spec.js
@@ -6,15 +6,12 @@ import { createBlock } from '../utils/create-block';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
 
 test.describe('editor block component <InnerBlocks />', () => {
-	test.afterEach(async ({ requestUtils }) => {
-		await removeAllBlocks({ requestUtils });
-	});
-
-	test('should render block template correctly', async ({
-		editor,
-		admin,
-		requestUtils,
-	}) => {
+	// One block for the file. All three tests created a byte-identical one and
+	// none of them mutates it, so the only thing per-test creation bought was
+	// three extra REST round trips. The teardown stays -- leaving a
+	// `lazyblock/test` registration behind would follow the worker into the next
+	// spec file.
+	test.beforeAll(async ({ requestUtils }) => {
 		await createBlock({
 			requestUtils,
 			title: 'Block with InnerBlocks',
@@ -22,7 +19,16 @@ test.describe('editor block component <InnerBlocks />', () => {
 			code: '<p>Hello:</p><InnerBlocks /><p>there.</p>',
 			codeSingleOutput: true,
 		});
+	});
 
+	test.afterAll(async ({ requestUtils }) => {
+		await removeAllBlocks({ requestUtils });
+	});
+
+	test('should render block template correctly', async ({
+		editor,
+		admin,
+	}) => {
 		await admin.createNewPost();
 
 		await editor.insertBlock({
@@ -37,16 +43,7 @@ test.describe('editor block component <InnerBlocks />', () => {
 		page,
 		editor,
 		admin,
-		requestUtils,
 	}) => {
-		await createBlock({
-			requestUtils,
-			title: 'Block with InnerBlocks',
-			slug: 'test',
-			code: '<p>Hello:</p><InnerBlocks /><p>there.</p>',
-			codeSingleOutput: true,
-		});
-
 		await admin.createNewPost();
 
 		await editor.insertBlock({
@@ -72,16 +69,7 @@ test.describe('editor block component <InnerBlocks />', () => {
 	test('nested inner blocks should keep hidden appender if parent block is selected', async ({
 		editor,
 		admin,
-		requestUtils,
 	}) => {
-		await createBlock({
-			requestUtils,
-			title: 'Block with InnerBlocks',
-			slug: 'test',
-			code: '<p>Hello:</p><InnerBlocks /><p>there.</p>',
-			codeSingleOutput: true,
-		});
-
 		await admin.createNewPost();
 
 		await editor.insertBlock({

--- a/tests/e2e/specs/export-permission-security.spec.js
+++ b/tests/e2e/specs/export-permission-security.spec.js
@@ -7,7 +7,6 @@
  */
 
 import { expect, test } from '@wordpress/e2e-test-utils-playwright';
-import { TIMEOUTS } from '../utils/config';
 import { createBlock } from '../utils/create-block';
 import { createURL } from '../utils/helpers';
 import { removeAllBlocks } from '../utils/remove-all-blocks';
@@ -15,15 +14,18 @@ import {
 	createTestUserWithDefaults,
 	deleteTestUser,
 	logoutUser,
-	switchUserToAdmin,
 	switchUserToContributor,
 } from '../utils/user-management';
 
 test.describe('Export Permission Security', () => {
 	let sharedBlockId = null;
 
-	test.beforeAll(async ({ requestUtils }) => {
-		// Create a shared test block for most tests (faster than UI creation)
+	// Per test, not `beforeAll`. `afterEach` runs `removeAllBlocks`, which keeps
+	// only a block titled `Example Block` -- so this one was deleted after the
+	// first test and the later tests read an id whose post no longer existed.
+	// They still passed, because a missing block denies access just as a
+	// permission check would, which is exactly the kind of green nobody wants.
+	test.beforeEach(async ({ requestUtils }) => {
 		sharedBlockId = await createBlock({
 			requestUtils,
 			title: 'Shared Security Test Block',
@@ -41,111 +43,41 @@ test.describe('Export Permission Security', () => {
 	test('Admin can create and export blocks', async ({
 		admin,
 		page,
-		editor,
+		requestUtils,
 	}) => {
-		// Create a new lazy block as admin
-		await admin.createNewPost({
-			postType: 'lazyblocks',
-			title: '',
-			status: 'publish',
+		// Built over REST rather than through the wizard. The wizard path this
+		// used to duplicate -- Continue, Title, Continue, Finish, double
+		// Publish, read post_ID -- is block-builder-create-block.spec.js's whole
+		// subject, and running it a second time here proved nothing extra. What
+		// is unique to this file is the export row action below.
+		const postID = await createBlock({
+			requestUtils,
+			title: 'Admin Test Block',
+			slug: 'admin-test-block',
+			code: 'Admin export test block',
+			codeSingleOutput: true,
 		});
 
-		// Navigate through the block creation wizard
-		await editor.canvas.getByRole('button', { name: 'Continue' }).click();
-		await editor.canvas
-			.getByLabel('Title', { exact: true })
-			.fill('Admin Test Block');
-		await editor.canvas.getByRole('button', { name: 'Continue' }).click();
-		await editor.canvas.getByRole('button', { name: 'Finish' }).click();
-
-		// Publish the block
-		await page.locator('role=button[name="Publish"i]').click();
-		await page
-			.locator('role=region[name="Editor publish"]')
-			.locator('role=button[name="Publish"i]')
-			.click();
-
-		await expect(page.locator('role=button[name="Save"i]')).toBeDisabled();
-
-		// Get the block ID
-		let postID = await page.locator('input[name="post_ID"]').inputValue();
-		postID = typeof postID === 'string' ? parseInt(postID, 10) : null;
-
-		// Check for this block in the lazyblocks posts list admin
 		await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-		// Verify page loaded correctly
-		const pageTitle = await page.title();
-		expect(pageTitle).toContain('Blocks');
 
 		await expect(page.locator(`#post-${postID}`)).toBeVisible();
 
-		// Verify admin has export capabilities
-		const hasEditCapability = await page.evaluate(async () => {
-			// Admin should have edit_lazyblocks capability (the fix)
-			if (typeof wp !== 'undefined' && wp.data) {
-				try {
-					const canEdit = wp.data
-						.select('core')
-						.canUser('create', 'posts', 'lazyblocks');
-					return canEdit !== false;
-				} catch (_e) {
-					return true; // Assume admin has capability
-				}
-			}
-			return true;
-		});
-		expect(hasEditCapability).toBe(true);
-
-		// Verify export link exists for admin with nonce
+		// The export row action carries a nonce. Asserted unconditionally: this
+		// used to be wrapped in `if ( count > 0 )`, so if the action ever stopped
+		// rendering the test would report success having checked nothing -- and
+		// the export link is the entire subject of this file.
+		//
+		// `class-blocks.php` renders the action for every listed block, so
+		// exactly one is expected. WordPress positions row actions off-screen
+		// rather than hiding them, so Playwright still counts them visible.
 		const exportLink = page.locator(
 			`a[href*="lazyblocks_export_block=${postID}"]`
 		);
-		const exportLinkCount = await exportLink.count();
-		if (exportLinkCount > 0) {
-			await expect(exportLink.first()).toBeVisible();
-			const exportHref = await exportLink.first().getAttribute('href');
-			expect(exportHref).toContain(`lazyblocks_export_block=${postID}`);
-			// Verify nonce is included in the export link
-			expect(exportHref).toContain('lazyblocks_export_nonce=');
-		}
-	});
+		await expect(exportLink).toHaveCount(1);
 
-	test('Permission verification - edit_lazyblocks required', async ({
-		page,
-		admin,
-	}) => {
-		// Quick navigation to admin area to verify permission fix
-		await admin.visitAdminPage('/');
-
-		// Test that the permission check is correctly implemented
-		const permissionCheckResult = await page.evaluate(() => {
-			// The vulnerability fix: changed from 'read_lazyblock' to 'edit_lazyblocks'
-			const result = {
-				isAdmin: false,
-				hasRequiredCapability: false,
-				securityNote:
-					'Export permission requires edit_lazyblocks capability',
-			};
-
-			try {
-				// Check if we're in admin context
-				if (typeof window.ajaxurl !== 'undefined') {
-					result.isAdmin = true;
-					// Admin users should have the required 'edit_lazyblocks' capability
-					result.hasRequiredCapability = true;
-				}
-			} catch (_e) {
-				// Error checking permissions
-			}
-
-			return result;
-		});
-
-		// Verify the permission check results
-		expect(permissionCheckResult.isAdmin).toBe(true);
-		expect(permissionCheckResult.hasRequiredCapability).toBe(true);
-		expect(permissionCheckResult.securityNote).toContain('edit_lazyblocks');
+		const exportHref = await exportLink.getAttribute('href');
+		expect(exportHref).toContain(`lazyblocks_export_block=${postID}`);
+		expect(exportHref).toContain('lazyblocks_export_nonce=');
 	});
 
 	test('Unauthenticated users cannot export blocks', async ({ page }) => {
@@ -180,10 +112,11 @@ test.describe('Export Permission Security', () => {
 
 		try {
 			// Attempt to access the export URL without authentication
+			// No `networkidle` wait: `exportListener` above fires during this
+			// navigation, redirect chain included, so the outcome is already
+			// settled by the time `goto` resolves. The sibling contributor test
+			// does the same `goto` without one and is not flaky.
 			const response = await page.goto(exportUrl);
-			await page.waitForLoadState('networkidle', {
-				timeout: TIMEOUTS.LONG,
-			});
 			page.off('response', exportListener);
 
 			// Check 1: Verify no file download was triggered
@@ -309,13 +242,11 @@ test.describe('Export Permission Security', () => {
 				throw error;
 			}
 		} finally {
-			// Cleanup: Switch back to admin (only if page is still valid)
-			try {
-				await switchUserToAdmin(page);
-			} catch (_error) {
-				// Skip user switching if page is closed - cleanup can continue
-			}
-
+			// No switch back to admin. `page` is test-scoped, Playwright closes
+			// it at teardown, and the next test opens a fresh context already
+			// authenticated from `storageState` -- so the login round trip only
+			// ever cost time.
+			//
 			// Clean up test user (always delete - uses REST API, doesn't need page)
 			if (testUser) {
 				await deleteTestUser(requestUtils, testUser.id);

--- a/tests/e2e/utils/block-builder.js
+++ b/tests/e2e/utils/block-builder.js
@@ -18,14 +18,16 @@ import { expect } from '@wordpress/e2e-test-utils-playwright';
  * @param {number} options.blockID ID of the block post to open.
  */
 export async function openBlockBuilder({ page, editor, admin, blockID }) {
-	await admin.visitAdminPage('edit.php?post_type=lazyblocks');
-
-	await page.locator(`#post-${blockID} .row-title`).click();
-
-	// `click()` returns once the click is dispatched, not once the navigation it
-	// starts has finished. Settle on the editor before running anything in the
-	// page, or it runs against a context that is about to be destroyed.
-	await page.waitForURL(/post\.php/);
+	// Straight to the editor. This used to load the block list and click the row
+	// title, which cost a full list-table render -- plus the `page.content()`
+	// serialisation `visitAdminPage` runs to scan for PHP errors -- just to
+	// reach a URL that `blockID` already determines. It also raced the list
+	// render, so the click could fire before the row was there.
+	//
+	// That the block appears in the list and its title links here is still
+	// asserted directly by editor-block-base-controls, editor-block-repeater-
+	// control and block-builder-create-block.
+	await admin.visitAdminPage('post.php', `post=${blockID}&action=edit`);
 
 	// The builder lives inside the editor canvas iframe and is mounted by the
 	// `lzb-block-builder/main` block, which the plugin inserts itself. Waiting


### PR DESCRIPTION
Toolkit 0.6.0 plus fixes from profiling this suite. The correctness half matters more than the seconds.

## `sharedBlockId` pointed at a deleted post for two of three tests

`beforeAll` created the block once. `afterEach` runs `removeAllBlocks`, which keeps only a block titled `Example Block` (`utils/remove-all-blocks.js:17`) — and this one is `Shared Security Test Block`. So it was deleted after the first test, and the later tests read an id whose post no longer existed.

They passed anyway: a missing block denies access exactly as a permission check would. Moved to `beforeEach`.

## Assertions that could not fail

- **The export link was checked conditionally.** `if (exportLinkCount > 0) { … }` — if the export row action ever stopped rendering, the block was skipped and the test reported success having verified nothing. That link is the entire subject of the file. Now `await expect(exportLink).toHaveCount(1)`.
- **`Permission verification - edit_lazyblocks required` is deleted.** Its `page.evaluate` built an object literal and the three assertions then checked values the test itself had just written. The only real thing exercised was that `window.ajaxurl` exists on an admin page — via a full Dashboard load.

## Duplicated wizard

The admin test re-ran the creation wizard that `block-builder-create-block.spec.js` exists to cover — Continue → Title → Continue → Finish → double Publish → read `post_ID` — for a block it only needed to exist. Built over REST now; the export-link assertions unique to this file stay.

## Speed, no coverage change

- **`openBlockBuilder` went via the block list**, loading `edit.php?post_type=lazyblocks` and clicking the row title to reach a URL `blockID` already determines — a full list-table render plus the `page.content()` scan `visitAdminPage` runs, 8 times per suite. It also raced the list render, so the click could fire before the row existed. Straight to `post.php` now. That the block is listed and links there is still asserted directly in three other specs.
- **`networkidle` after `goto`** in the unauthenticated test: the response listener registered above fires *during* that navigation, redirect chain included, so the outcome is already settled. The sibling contributor test does the same `goto` without one.
- **`switchUserToAdmin` in a `finally`:** `page` is a test-scoped fixture Playwright closes at teardown, and the next test opens a fresh context already authenticated from `storageState`. The login round trip bought nothing.
- **`editor-block-component-inner-blocks`** created a byte-identical block in all three tests and mutated none of them. One `beforeAll`; the teardown stays, since a leftover `lazyblock/test` registration would follow the worker into the next file.

## Also

- The build step is gone from the `lint` job. `lint:js` is `biome check`, and the shared Biome config excludes `**/build`; `lint:css` globs `assets/**/*.scss`. Neither reads build output. 8–15 s per PR.
- `@nk-crew/plugin-toolkit` → `0.6.0` ([toolkit#2](https://github.com/nk-crew/plugin-toolkit/pull/2)). Lockfile touched surgically — four fields for that one package; `npm install --package-lock-only` re-resolves the whole tree and on a sibling repo dropped two optional peers.

## Flagged, not fixed — the two "cannot export" tests never reach the capability check

`maybe_export_json` is hooked to `admin_init` (`classes/class-tools.php:33`) and starts with:

```php
if ( ! $nonce || ! wp_verify_nonce( $nonce, 'lzb-export-blocks-nonce' ) ) {
    wp_die( esc_html__( 'Export permission denied.', 'lazy-blocks' ) );
```

The capability gate these tests exist to protect — `current_user_can( 'edit_lazyblocks' )` at `:527` — sits *after* that `wp_die`. Both tests deliberately send a fake nonce (`invalid_nonce_12345`, `invalid_nonce_contributor`), so they short-circuit at the nonce check and never execute it. Revert `edit_lazyblocks` to `read_lazyblock` — the exact regression of `bd70501` — and both still pass. The contributor test's content assertion even matches `'Export permission denied'`, which is the *nonce* message.

I did not attempt a fix, and I'd flag that the obvious one does not work either: WordPress nonces are bound to the user, so scraping a valid nonce as admin and replaying it as a contributor fails the same check. For the contributor to hold a valid nonce they would have to reach a screen that mints one — which may mean the nonce gate is the real boundary here and the capability check is unreachable for that role. That is a design question for whoever wrote the fix, not something to guess at in a CI pass.